### PR TITLE
Update devcontainer for extended local support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,10 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go",
-	"image": "mcr.microsoft.com/devcontainers/go:0-1-bullseye",
-
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
+	"name": "aws-source",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "devcontainer",
+	"workspaceFolder": "/workspace",
 
 	// Configure tool-specific properties.
 	"customizations": {
@@ -19,20 +18,16 @@
 			}
 		}
 	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/aws-cli:1": {}
 	},
-
-	// Mount the user's AWS config so that the CLI works as expected
-	"mounts": [
-        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached"
-    ]
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "go version",
+	"postCreateCommand": "go mod vendor",
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  devcontainer:
+    image: "mcr.microsoft.com/devcontainers/go:0-1-bullseye"
+    volumes:
+      - ..:/workspace:cached
+      # mount the user's AWS config so that the CLI works as expected
+      - ~/.aws:/home/vscode/.aws:cached
+      # make the rest of the checkouts from the host available, so that
+      # cross-mod changes can be developed and tested inside the container
+      - ../..:/sources
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Uncomment the next line to use a non-root user for all processes.
+    user: vscode
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)


### PR DESCRIPTION
* mount the parent directory of the checkout to `/sources`. This allows adding `replace $mod => /sources/$repo` to `go.mod` file to temporarily use a local checkout of something else.
* move container config to docker-compose. This is required to be able to use relative and `~` sources.
* set a devcontainer name to fix the window title
* always run go mod vendor on container create