### PR TITLE
Moved many terraform links to SEARCH queries

### DIFF
--- a/docs-data/autoscaling-auto-scaling-group.json
+++ b/docs-data/autoscaling-auto-scaling-group.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for Autoscaling Groups by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_autoscaling_group.name"
+		"aws_autoscaling_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"autoscaling-launch-configuration",

--- a/docs-data/dynamodb-table.json
+++ b/docs-data/dynamodb-table.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for DynamoDB tables by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_dynamodb_table.name"
+		"aws_dynamodb_table.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"backup-recovery-point",

--- a/docs-data/ecs-capacity-provider.json
+++ b/docs-data/ecs-capacity-provider.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search capacity providers by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_ecs_capacity_provider.name"
+		"aws_ecs_capacity_provider.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"autoscaling-auto-scaling-group"

--- a/docs-data/ecs-cluster.json
+++ b/docs-data/ecs-cluster.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for a cluster by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_ecs_cluster.name"
+		"aws_ecs_cluster.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"ecs-capacity-provider",

--- a/docs-data/eks-cluster.json
+++ b/docs-data/eks-cluster.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for clusters by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_eks_cluster.name"
+		"aws_eks_cluster.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"ec2-security-group",

--- a/docs-data/elb-load-balancer.json
+++ b/docs-data/elb-load-balancer.json
@@ -6,10 +6,9 @@
 	"searchDescription": "Search for classic load balancers by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_elb.name",
-		"aws_elb_attachment.elb"
+		"aws_elb.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"dns",

--- a/docs-data/elbv2-load-balancer.json
+++ b/docs-data/elbv2-load-balancer.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for ELBs by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_lb.name"
+		"aws_lb.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"dns",

--- a/docs-data/elbv2-target-group.json
+++ b/docs-data/elbv2-target-group.json
@@ -6,10 +6,10 @@
 	"searchDescription": "Search for target groups by load balancer ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_alb_target_group.name",
-		"aws_lb_target_group.name"
+		"aws_alb_target_group.arn",
+		"aws_lb_target_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"ec2-vpc",

--- a/docs-data/iam-group.json
+++ b/docs-data/iam-group.json
@@ -6,11 +6,9 @@
 	"searchDescription": "Search for a group by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_iam_group.name",
-		"aws_iam_group_membership.group",
-		"aws_iam_user_group_membership.group"
+		"aws_iam_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": []
 }

--- a/docs-data/iam-role.json
+++ b/docs-data/iam-role.json
@@ -6,10 +6,9 @@
 	"searchDescription": "Search for IAM roles by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_iam_role.name",
-		"aws_iam_role_policy_attachment.role"
+		"aws_iam_role.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"iam-policy"

--- a/docs-data/iam-user.json
+++ b/docs-data/iam-user.json
@@ -6,12 +6,9 @@
 	"searchDescription": "Search for users by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_iam_user.name",
-		"aws_iam_user_group_membership.user",
-		"aws_iam_user_policy.user",
-		"aws_iam_user_policy_attachment.user"
+		"aws_iam_user.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"iam-group"

--- a/docs-data/lambda-function.json
+++ b/docs-data/lambda-function.json
@@ -6,12 +6,11 @@
 	"searchDescription": "Search for lambda functions by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_lambda_function.name",
-		"aws_lambda_function_event_invoke_config.function_name",
-		"aws_lambda_function_url.function_name",
-		"aws_lambda_invocation.function_name"
+		"aws_lambda_function.arn",
+		"aws_lambda_function_event_invoke_config.id",
+		"aws_lambda_function_url.function_arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"ec2-security-group",

--- a/docs-data/rds-db-cluster-parameter-group.json
+++ b/docs-data/rds-db-cluster-parameter-group.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for a parameter group by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_rds_cluster_parameter_group.name"
+		"aws_rds_cluster_parameter_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": []
 }

--- a/docs-data/rds-db-parameter-group.json
+++ b/docs-data/rds-db-parameter-group.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for a parameter group by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_db_parameter_group.name"
+		"aws_db_parameter_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": []
 }

--- a/docs-data/rds-db-subnet-group.json
+++ b/docs-data/rds-db-subnet-group.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for subnet groups by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_db_subnet_group.name"
+		"aws_db_subnet_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"ec2-availability-zone",

--- a/docs-data/rds-option-group.json
+++ b/docs-data/rds-option-group.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for an option group by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_db_option_group.name"
+		"aws_db_option_group.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": []
 }

--- a/docs-data/route53-resource-record-set.json
+++ b/docs-data/route53-resource-record-set.json
@@ -6,9 +6,9 @@
 	"searchDescription": "Search for a record set by ARN",
 	"group": "AWS",
 	"terraformQuery": [
-		"aws_route53_record.name"
+		"aws_route53_record.arn"
 	],
-	"terraformMethod": "GET",
+	"terraformMethod": "SEARCH",
 	"terraformScope": "*",
 	"links": [
 		"dns"

--- a/sources/autoscaling/auto_scaling_group.go
+++ b/sources/autoscaling/auto_scaling_group.go
@@ -224,7 +224,8 @@ func autoScalingGroupOutputMapper(scope string, _ *autoscaling.DescribeAutoScali
 // +overmind:list List Autoscaling Groups
 // +overmind:search Search for Autoscaling Groups by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_autoscaling_group.name
+// +overmind:terraform:queryMap aws_autoscaling_group.arn
+// +overmind:terraform:method SEARCH
 //
 //go:generate docgen ../../docs-data
 func NewAutoScalingGroupSource(config aws.Config, accountID string, limit *sources.LimitBucket) *sources.DescribeOnlySource[*autoscaling.DescribeAutoScalingGroupsInput, *autoscaling.DescribeAutoScalingGroupsOutput, *autoscaling.Client, *autoscaling.Options] {

--- a/sources/dynamodb/table.go
+++ b/sources/dynamodb/table.go
@@ -165,7 +165,8 @@ func tableGetFunc(ctx context.Context, client Client, scope string, input *dynam
 // +overmind:list List all DynamoDB tables
 // +overmind:search Search for DynamoDB tables by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_dynamodb_table.name
+// +overmind:terraform:queryMap aws_dynamodb_table.arn
+// +overmind:terraform:method SEARCH
 
 func NewTableSource(config aws.Config, accountID string, region string) *sources.AlwaysGetSource[*dynamodb.ListTablesInput, *dynamodb.ListTablesOutput, *dynamodb.DescribeTableInput, *dynamodb.DescribeTableOutput, Client, *dynamodb.Options] {
 	return &sources.AlwaysGetSource[*dynamodb.ListTablesInput, *dynamodb.ListTablesOutput, *dynamodb.DescribeTableInput, *dynamodb.DescribeTableOutput, Client, *dynamodb.Options]{

--- a/sources/ecs/capacity_provider.go
+++ b/sources/ecs/capacity_provider.go
@@ -66,7 +66,8 @@ func capacityProviderOutputMapper(scope string, _ *ecs.DescribeCapacityProviders
 // +overmind:list List all capacity providers
 // +overmind:search Search capacity providers by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_ecs_capacity_provider.name
+// +overmind:terraform:queryMap aws_ecs_capacity_provider.arn
+// +overmind:terraform:method SEARCH
 
 func NewCapacityProviderSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*ecs.DescribeCapacityProvidersInput, *ecs.DescribeCapacityProvidersOutput, ECSClient, *ecs.Options] {
 	return &sources.DescribeOnlySource[*ecs.DescribeCapacityProvidersInput, *ecs.DescribeCapacityProvidersOutput, ECSClient, *ecs.Options]{

--- a/sources/ecs/cluster.go
+++ b/sources/ecs/cluster.go
@@ -211,7 +211,8 @@ func clusterGetFunc(ctx context.Context, client ECSClient, scope string, input *
 // +overmind:list List all clusters
 // +overmind:search Search for a cluster by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_ecs_cluster.name
+// +overmind:terraform:queryMap aws_ecs_cluster.arn
+// +overmind:terraform:method SEARCH
 
 func NewClusterSource(config aws.Config, accountID string, region string) *sources.AlwaysGetSource[*ecs.ListClustersInput, *ecs.ListClustersOutput, *ecs.DescribeClustersInput, *ecs.DescribeClustersOutput, ECSClient, *ecs.Options] {
 	return &sources.AlwaysGetSource[*ecs.ListClustersInput, *ecs.ListClustersOutput, *ecs.DescribeClustersInput, *ecs.DescribeClustersOutput, ECSClient, *ecs.Options]{

--- a/sources/eks/cluster.go
+++ b/sources/eks/cluster.go
@@ -268,7 +268,8 @@ func clusterGetFunc(ctx context.Context, client EKSClient, scope string, input *
 // +overmind:list List all clusters
 // +overmind:search Search for clusters by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_eks_cluster.name
+// +overmind:terraform:queryMap aws_eks_cluster.arn
+// +overmind:terraform:method SEARCH
 
 func NewClusterSource(config aws.Config, accountID string, region string) *sources.AlwaysGetSource[*eks.ListClustersInput, *eks.ListClustersOutput, *eks.DescribeClusterInput, *eks.DescribeClusterOutput, EKSClient, *eks.Options] {
 	return &sources.AlwaysGetSource[*eks.ListClustersInput, *eks.ListClustersOutput, *eks.DescribeClusterInput, *eks.DescribeClusterOutput, EKSClient, *eks.Options]{

--- a/sources/elb/elb.go
+++ b/sources/elb/elb.go
@@ -150,8 +150,8 @@ func loadBalancerOutputMapper(scope string, _ *elb.DescribeLoadBalancersInput, o
 // +overmind:list List all classic load balancers
 // +overmind:search Search for classic load balancers by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_elb.name
-// +overmind:terraform:queryMap aws_elb_attachment.elb
+// +overmind:terraform:queryMap aws_elb.arn
+// +overmind:terraform:method SEARCH
 
 func NewLoadBalancerSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*elb.DescribeLoadBalancersInput, *elb.DescribeLoadBalancersOutput, *elb.Client, *elb.Options] {
 	return &sources.DescribeOnlySource[*elb.DescribeLoadBalancersInput, *elb.DescribeLoadBalancersOutput, *elb.Client, *elb.Options]{

--- a/sources/elbv2/elb.go
+++ b/sources/elbv2/elb.go
@@ -270,7 +270,8 @@ func loadBalancerOutputMapper(scope string, _ *elbv2.DescribeLoadBalancersInput,
 // +overmind:list List all ELBs
 // +overmind:search Search for ELBs by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_lb.name
+// +overmind:terraform:queryMap aws_lb.arn
+// +overmind:terraform:method SEARCH
 
 func NewLoadBalancerSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*elbv2.DescribeLoadBalancersInput, *elbv2.DescribeLoadBalancersOutput, *elbv2.Client, *elbv2.Options] {
 	return &sources.DescribeOnlySource[*elbv2.DescribeLoadBalancersInput, *elbv2.DescribeLoadBalancersOutput, *elbv2.Client, *elbv2.Options]{

--- a/sources/elbv2/target_group.go
+++ b/sources/elbv2/target_group.go
@@ -93,8 +93,9 @@ func targetGroupOutputMapper(scope string, _ *elbv2.DescribeTargetGroupsInput, o
 // +overmind:list List all target groups
 // +overmind:search Search for target groups by load balancer ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_alb_target_group.name
-// +overmind:terraform:queryMap aws_lb_target_group.name
+// +overmind:terraform:queryMap aws_alb_target_group.arn
+// +overmind:terraform:queryMap aws_lb_target_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewTargetGroupSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*elbv2.DescribeTargetGroupsInput, *elbv2.DescribeTargetGroupsOutput, *elbv2.Client, *elbv2.Options] {
 	return &sources.DescribeOnlySource[*elbv2.DescribeTargetGroupsInput, *elbv2.DescribeTargetGroupsOutput, *elbv2.Client, *elbv2.Options]{

--- a/sources/iam/group.go
+++ b/sources/iam/group.go
@@ -64,9 +64,8 @@ func groupItemMapper(scope string, awsItem *types.Group) (*sdp.Item, error) {
 // +overmind:list List all IAM groups
 // +overmind:search Search for a group by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_iam_group.name
-// +overmind:terraform:queryMap aws_iam_group_membership.group
-// +overmind:terraform:queryMap aws_iam_user_group_membership.group
+// +overmind:terraform:queryMap aws_iam_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewGroupSource(config aws.Config, accountID string, region string, limit *sources.LimitBucket) *sources.GetListSource[*types.Group, *iam.Client, *iam.Options] {
 	return &sources.GetListSource[*types.Group, *iam.Client, *iam.Options]{

--- a/sources/iam/role.go
+++ b/sources/iam/role.go
@@ -255,8 +255,8 @@ func roleItemMapper(scope string, awsItem *RoleDetails) (*sdp.Item, error) {
 // +overmind:list List all IAM roles
 // +overmind:search Search for IAM roles by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_iam_role.name
-// +overmind:terraform:queryMap aws_iam_role_policy_attachment.role
+// +overmind:terraform:queryMap aws_iam_role.arn
+// +overmind:terraform:method SEARCH
 
 func NewRoleSource(config aws.Config, accountID string, region string, limit *sources.LimitBucket) *sources.GetListSource[*RoleDetails, IAMClient, *iam.Options] {
 	return &sources.GetListSource[*RoleDetails, IAMClient, *iam.Options]{

--- a/sources/iam/user.go
+++ b/sources/iam/user.go
@@ -184,10 +184,8 @@ func userItemMapper(scope string, awsItem *UserDetails) (*sdp.Item, error) {
 // +overmind:list List all users
 // +overmind:search Search for users by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_iam_user.name
-// +overmind:terraform:queryMap aws_iam_user_group_membership.user
-// +overmind:terraform:queryMap aws_iam_user_policy.user
-// +overmind:terraform:queryMap aws_iam_user_policy_attachment.user
+// +overmind:terraform:queryMap aws_iam_user.arn
+// +overmind:terraform:method SEARCH
 
 func NewUserSource(config aws.Config, accountID string, region string, limit *sources.LimitBucket) *sources.GetListSource[*UserDetails, IAMClient, *iam.Options] {
 	return &sources.GetListSource[*UserDetails, IAMClient, *iam.Options]{

--- a/sources/lambda/function.go
+++ b/sources/lambda/function.go
@@ -547,10 +547,10 @@ func GetEventLinkedItem(destinationARN string) (*sdp.LinkedItemQuery, error) {
 // +overmind:list List all lambda functions
 // +overmind:search Search for lambda functions by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_lambda_function.name
-// +overmind:terraform:queryMap aws_lambda_function_event_invoke_config.function_name
-// +overmind:terraform:queryMap aws_lambda_function_url.function_name
-// +overmind:terraform:queryMap aws_lambda_invocation.function_name
+// +overmind:terraform:queryMap aws_lambda_function.arn
+// +overmind:terraform:queryMap aws_lambda_function_event_invoke_config.id
+// +overmind:terraform:queryMap aws_lambda_function_url.function_arn
+// +overmind:terraform:method SEARCH
 
 func NewFunctionSource(config aws.Config, accountID string, region string) *sources.AlwaysGetSource[*lambda.ListFunctionsInput, *lambda.ListFunctionsOutput, *lambda.GetFunctionInput, *lambda.GetFunctionOutput, LambdaClient, *lambda.Options] {
 	return &sources.AlwaysGetSource[*lambda.ListFunctionsInput, *lambda.ListFunctionsOutput, *lambda.GetFunctionInput, *lambda.GetFunctionOutput, LambdaClient, *lambda.Options]{

--- a/sources/rds/db_cluster_parameter_group.go
+++ b/sources/rds/db_cluster_parameter_group.go
@@ -41,7 +41,8 @@ func dBClusterParameterGroupItemMapper(scope string, awsItem *ClusterParameterGr
 // +overmind:list List all RDS parameter groups
 // +overmind:search Search for a parameter group by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_rds_cluster_parameter_group.name
+// +overmind:terraform:queryMap aws_rds_cluster_parameter_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewDBClusterParameterGroupSource(config aws.Config, accountID string, region string) *sources.GetListSource[*ClusterParameterGroup, *rds.Client, *rds.Options] {
 	return &sources.GetListSource[*ClusterParameterGroup, *rds.Client, *rds.Options]{

--- a/sources/rds/db_parameter_group.go
+++ b/sources/rds/db_parameter_group.go
@@ -41,7 +41,8 @@ func dBParameterGroupItemMapper(scope string, awsItem *ParameterGroup) (*sdp.Ite
 // +overmind:list List all parameter groups
 // +overmind:search Search for a parameter group by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_db_parameter_group.name
+// +overmind:terraform:queryMap aws_db_parameter_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewDBParameterGroupSource(config aws.Config, accountID string, region string) *sources.GetListSource[*ParameterGroup, *rds.Client, *rds.Options] {
 	return &sources.GetListSource[*ParameterGroup, *rds.Client, *rds.Options]{

--- a/sources/rds/db_subnet_group.go
+++ b/sources/rds/db_subnet_group.go
@@ -121,7 +121,8 @@ func dBSubnetGroupOutputMapper(scope string, _ *rds.DescribeDBSubnetGroupsInput,
 // +overmind:list List all subnet groups
 // +overmind:search Search for subnet groups by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_db_subnet_group.name
+// +overmind:terraform:queryMap aws_db_subnet_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewDBSubnetGroupSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*rds.DescribeDBSubnetGroupsInput, *rds.DescribeDBSubnetGroupsOutput, *rds.Client, *rds.Options] {
 	return &sources.DescribeOnlySource[*rds.DescribeDBSubnetGroupsInput, *rds.DescribeDBSubnetGroupsOutput, *rds.Client, *rds.Options]{

--- a/sources/rds/option_group.go
+++ b/sources/rds/option_group.go
@@ -39,7 +39,8 @@ func optionGroupOutputMapper(scope string, _ *rds.DescribeOptionGroupsInput, out
 // +overmind:list List all RDS option groups
 // +overmind:search Search for an option group by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_db_option_group.name
+// +overmind:terraform:queryMap aws_db_option_group.arn
+// +overmind:terraform:method SEARCH
 
 func NewOptionGroupSource(config aws.Config, accountID string) *sources.DescribeOnlySource[*rds.DescribeOptionGroupsInput, *rds.DescribeOptionGroupsOutput, *rds.Client, *rds.Options] {
 	return &sources.DescribeOnlySource[*rds.DescribeOptionGroupsInput, *rds.DescribeOptionGroupsOutput, *rds.Client, *rds.Options]{

--- a/sources/route53/resource_record_set.go
+++ b/sources/route53/resource_record_set.go
@@ -78,7 +78,8 @@ func resourceRecordSetItemMapper(scope string, awsItem *types.ResourceRecordSet)
 // +overmind:list List all record sets
 // +overmind:search Search for a record set by ARN
 // +overmind:group AWS
-// +overmind:terraform:queryMap aws_route53_record.name
+// +overmind:terraform:queryMap aws_route53_record.arn
+// +overmind:terraform:method SEARCH
 
 func NewResourceRecordSetSource(config aws.Config, accountID string, region string) *sources.GetListSource[*types.ResourceRecordSet, *route53.Client, *route53.Options] {
 	return &sources.GetListSource[*types.ResourceRecordSet, *route53.Client, *route53.Options]{


### PR DESCRIPTION
This means that there will no longer be clashes when there are many resources with the same name in different accounts or regions

This will fix https://github.com/overmindtech/docgen/issues/8. There was no need for improved scope mapping here since there wasn't a good way to get the scope from the provider, the resource was the only thing that contained the correct information so a SEARCH on an ARN with a scope of `*` will be equivalent to a GET request for the resource in the correct scope