### PR TITLE
Ensure we actually set a cache duration

### DIFF
--- a/sources/always_get_source.go
+++ b/sources/always_get_source.go
@@ -75,10 +75,9 @@ type AlwaysGetSource[ListInput InputType, ListOutput OutputType, GetInput InputT
 	cacheInitMu   sync.Mutex      // Mutex to ensure cache is only initialised once
 }
 
-// DefaultCacheDuration Returns the default cache duration for this source
-func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruct, Options]) DefaultCacheDuration() time.Duration {
+func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruct, Options]) cacheDuration() time.Duration {
 	if s.CacheDuration == 0 {
-		return 10 * time.Minute
+		return DefaultCacheDuration
 	}
 
 	return s.CacheDuration
@@ -170,11 +169,11 @@ func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruc
 	if err != nil {
 		// TODO: How can we handle NOTFOUND?
 		qErr := WrapAWSError(err)
-		s.cache.StoreError(qErr, s.CacheDuration, ck)
+		s.cache.StoreError(qErr, s.cacheDuration(), ck)
 		return nil, qErr
 	}
 
-	s.cache.StoreItem(item, s.CacheDuration, ck)
+	s.cache.StoreItem(item, s.cacheDuration(), ck)
 	return item, nil
 }
 
@@ -206,12 +205,12 @@ func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruc
 	items, err := s.listInternal(ctx, scope, s.ListInput)
 	if err != nil {
 		err = WrapAWSError(err)
-		s.cache.StoreError(err, s.CacheDuration, ck)
+		s.cache.StoreError(err, s.cacheDuration(), ck)
 		return nil, err
 	}
 
 	for _, item := range items {
-		s.cache.StoreItem(item, s.CacheDuration, ck)
+		s.cache.StoreItem(item, s.cacheDuration(), ck)
 	}
 
 	return items, nil
@@ -343,12 +342,12 @@ func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruc
 
 	if err != nil {
 		err = WrapAWSError(err)
-		s.cache.StoreError(err, s.CacheDuration, ck)
+		s.cache.StoreError(err, s.cacheDuration(), ck)
 		return nil, err
 	}
 
 	for _, item := range items {
-		s.cache.StoreItem(item, s.CacheDuration, ck)
+		s.cache.StoreItem(item, s.cacheDuration(), ck)
 	}
 
 	return items, nil
@@ -369,12 +368,12 @@ func (s *AlwaysGetSource[ListInput, ListOutput, GetInput, GetOutput, ClientStruc
 
 	if err != nil {
 		err = WrapAWSError(err)
-		s.cache.StoreError(err, s.CacheDuration, ck)
+		s.cache.StoreError(err, s.cacheDuration(), ck)
 		return nil, err
 	}
 
 	for _, item := range items {
-		s.cache.StoreItem(item, s.CacheDuration, ck)
+		s.cache.StoreItem(item, s.cacheDuration(), ck)
 	}
 	return items, nil
 }

--- a/sources/iam/group.go
+++ b/sources/iam/group.go
@@ -71,7 +71,7 @@ func NewGroupSource(config aws.Config, accountID string, region string, limit *s
 	return &sources.GetListSource[*types.Group, *iam.Client, *iam.Options]{
 		ItemType:      "iam-group",
 		Client:        iam.NewFromConfig(config),
-		CacheDuration: 1 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
+		CacheDuration: 3 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
 		AccountID:     accountID,
 		GetFunc: func(ctx context.Context, client *iam.Client, scope, query string) (*types.Group, error) {
 			limit.Wait(ctx) // Wait for rate limiting

--- a/sources/iam/instance_profile.go
+++ b/sources/iam/instance_profile.go
@@ -111,7 +111,7 @@ func NewInstanceProfileSource(config aws.Config, accountID string, region string
 	return &sources.GetListSource[*types.InstanceProfile, *iam.Client, *iam.Options]{
 		ItemType:      "iam-instance-profile",
 		Client:        iam.NewFromConfig(config),
-		CacheDuration: 1 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
+		CacheDuration: 3 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
 		AccountID:     accountID,
 		GetFunc: func(ctx context.Context, client *iam.Client, scope, query string) (*types.InstanceProfile, error) {
 			limit.Wait(ctx) // Wait for rate limiting

--- a/sources/iam/policy.go
+++ b/sources/iam/policy.go
@@ -306,7 +306,7 @@ func NewPolicySource(config aws.Config, accountID string, _ string, limit *sourc
 	return &sources.GetListSource[*PolicyDetails, IAMClient, *iam.Options]{
 		ItemType:      "iam-policy",
 		Client:        iam.NewFromConfig(config),
-		CacheDuration: 1 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
+		CacheDuration: 3 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
 		AccountID:     accountID,
 		Region:        "", // IAM policies aren't tied to a region
 

--- a/sources/iam/role.go
+++ b/sources/iam/role.go
@@ -298,7 +298,7 @@ func NewRoleSource(config aws.Config, accountID string, region string, limit *so
 	return &sources.GetListSource[*RoleDetails, IAMClient, *iam.Options]{
 		ItemType:      "iam-role",
 		Client:        iam.NewFromConfig(config),
-		CacheDuration: 1 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
+		CacheDuration: 3 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
 		AccountID:     accountID,
 		GetFunc: func(ctx context.Context, client IAMClient, scope, query string) (*RoleDetails, error) {
 			return roleGetFunc(ctx, client, scope, query, limit)

--- a/sources/iam/user.go
+++ b/sources/iam/user.go
@@ -192,7 +192,7 @@ func NewUserSource(config aws.Config, accountID string, region string, limit *so
 		ItemType:      "iam-user",
 		Client:        iam.NewFromConfig(config),
 		AccountID:     accountID,
-		CacheDuration: 1 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
+		CacheDuration: 3 * time.Hour, // IAM has very low rate limits, we need to cache for a long time
 		Region:        region,
 		GetFunc: func(ctx context.Context, client IAMClient, scope, query string) (*UserDetails, error) {
 			return userGetFunc(ctx, client, scope, query, limit)


### PR DESCRIPTION
Since the `CacheDuration` was empty, it defaulted to zero, making the cache not work. This means that sources can still set their own, but we also have a sane default