### PR TITLE
Don't return tags as attributes

### DIFF
--- a/sources/ec2/address.go
+++ b/sources/ec2/address.go
@@ -43,7 +43,7 @@ func addressOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.
 	}
 
 	for _, address := range output.Addresses {
-		attrs, err = sources.ToAttributesCase(address)
+		attrs, err = sources.ToAttributesCase(address, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/ec2/capacity_reservation.go
+++ b/sources/ec2/capacity_reservation.go
@@ -13,7 +13,7 @@ func capacityReservationOutputMapper(_ context.Context, _ *ec2.Client, scope str
 	items := make([]*sdp.Item, 0)
 
 	for _, cr := range output.CapacityReservations {
-		attributes, err := sources.ToAttributesCase(cr)
+		attributes, err := sources.ToAttributesCase(cr, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/ec2/capacity_reservation_fleet.go
+++ b/sources/ec2/capacity_reservation_fleet.go
@@ -14,7 +14,7 @@ func capacityReservationFleetOutputMapper(_ context.Context, _ *ec2.Client, scop
 	items := make([]*sdp.Item, 0)
 
 	for _, cr := range output.CapacityReservationFleets {
-		attributes, err := sources.ToAttributesCase(cr)
+		attributes, err := sources.ToAttributesCase(cr, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/ec2/egress_internet_gateway.go
+++ b/sources/ec2/egress_internet_gateway.go
@@ -27,7 +27,7 @@ func egressOnlyInternetGatewayOutputMapper(_ context.Context, _ *ec2.Client, sco
 	for _, gw := range output.EgressOnlyInternetGateways {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(gw)
+		attrs, err = sources.ToAttributesCase(gw, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/image.go
+++ b/sources/ec2/image.go
@@ -38,7 +38,7 @@ func imageOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.De
 	for _, image := range output.Images {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(image)
+		attrs, err = sources.ToAttributesCase(image, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/image_test.go
+++ b/sources/ec2/image_test.go
@@ -72,6 +72,12 @@ func TestImageOutputMapper(t *testing.T) {
 				RootDeviceType:     types.DeviceTypeEbs,
 				SriovNetSupport:    sources.PtrString("simple"),
 				VirtualizationType: types.VirtualizationTypeHvm,
+				Tags: []types.Tag{
+					{
+						Key:   sources.PtrString("Name"),
+						Value: sources.PtrString("test"),
+					},
+				},
 			},
 		},
 	}

--- a/sources/ec2/instance.go
+++ b/sources/ec2/instance.go
@@ -26,7 +26,7 @@ func instanceOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2
 
 	for _, reservation := range output.Reservations {
 		for _, instance := range reservation.Instances {
-			attrs, err := sources.ToAttributesCase(instance)
+			attrs, err := sources.ToAttributesCase(instance, "tags")
 
 			if err != nil {
 				return nil, &sdp.QueryError{

--- a/sources/ec2/instance_event_window.go
+++ b/sources/ec2/instance_event_window.go
@@ -25,7 +25,7 @@ func instanceEventWindowOutputMapper(_ context.Context, _ *ec2.Client, scope str
 	items := make([]*sdp.Item, 0)
 
 	for _, ew := range output.InstanceEventWindows {
-		attrs, err := sources.ToAttributesCase(ew)
+		attrs, err := sources.ToAttributesCase(ew, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/internet_gateway.go
+++ b/sources/ec2/internet_gateway.go
@@ -27,7 +27,7 @@ func internetGatewayOutputMapper(_ context.Context, _ *ec2.Client, scope string,
 	for _, gw := range output.InternetGateways {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(gw)
+		attrs, err = sources.ToAttributesCase(gw, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/key_pair.go
+++ b/sources/ec2/key_pair.go
@@ -27,7 +27,7 @@ func keyPairOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.
 	for _, gw := range output.KeyPairs {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(gw)
+		attrs, err = sources.ToAttributesCase(gw, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/launch_template.go
+++ b/sources/ec2/launch_template.go
@@ -27,7 +27,7 @@ func launchTemplateOutputMapper(_ context.Context, _ *ec2.Client, scope string, 
 	for _, LaunchTemplate := range output.LaunchTemplates {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(LaunchTemplate)
+		attrs, err = sources.ToAttributesCase(LaunchTemplate, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/nat_gateway.go
+++ b/sources/ec2/nat_gateway.go
@@ -27,7 +27,7 @@ func natGatewayOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *e
 	for _, ng := range output.NatGateways {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(ng)
+		attrs, err = sources.ToAttributesCase(ng, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/network_acl.go
+++ b/sources/ec2/network_acl.go
@@ -27,7 +27,7 @@ func networkAclOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *e
 	for _, networkAcl := range output.NetworkAcls {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(networkAcl)
+		attrs, err = sources.ToAttributesCase(networkAcl, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/network_interface.go
+++ b/sources/ec2/network_interface.go
@@ -27,7 +27,7 @@ func networkInterfaceOutputMapper(_ context.Context, _ *ec2.Client, scope string
 	for _, ni := range output.NetworkInterfaces {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(ni)
+		attrs, err = sources.ToAttributesCase(ni, "tagSet")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/placement_group.go
+++ b/sources/ec2/placement_group.go
@@ -27,7 +27,7 @@ func placementGroupOutputMapper(_ context.Context, _ *ec2.Client, scope string, 
 	for _, ng := range output.PlacementGroups {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(ng)
+		attrs, err = sources.ToAttributesCase(ng, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/reserved_instance.go
+++ b/sources/ec2/reserved_instance.go
@@ -25,7 +25,7 @@ func reservedInstanceOutputMapper(_ context.Context, _ *ec2.Client, scope string
 	items := make([]*sdp.Item, 0)
 
 	for _, reservation := range output.ReservedInstances {
-		attrs, err := sources.ToAttributesCase(reservation)
+		attrs, err := sources.ToAttributesCase(reservation, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/route_table.go
+++ b/sources/ec2/route_table.go
@@ -28,7 +28,7 @@ func routeTableOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *e
 	for _, rt := range output.RouteTables {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(rt)
+		attrs, err = sources.ToAttributesCase(rt, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/sg.go
+++ b/sources/ec2/sg.go
@@ -28,7 +28,7 @@ func securityGroupOutputMapper(_ context.Context, _ *ec2.Client, scope string, _
 	for _, securityGroup := range output.SecurityGroups {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(securityGroup)
+		attrs, err = sources.ToAttributesCase(securityGroup, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/sg_rule.go
+++ b/sources/ec2/sg_rule.go
@@ -27,7 +27,7 @@ func securityGroupRuleOutputMapper(_ context.Context, _ *ec2.Client, scope strin
 	for _, securityGroupRule := range output.SecurityGroupRules {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(securityGroupRule)
+		attrs, err = sources.ToAttributesCase(securityGroupRule, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/snapshot.go
+++ b/sources/ec2/snapshot.go
@@ -33,7 +33,7 @@ func snapshotOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2
 	for _, snapshot := range output.Snapshots {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(snapshot)
+		attrs, err = sources.ToAttributesCase(snapshot, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/subnet.go
+++ b/sources/ec2/subnet.go
@@ -27,7 +27,7 @@ func subnetOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.D
 	for _, subnet := range output.Subnets {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(subnet)
+		attrs, err = sources.ToAttributesCase(subnet, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/volume.go
+++ b/sources/ec2/volume.go
@@ -27,7 +27,7 @@ func volumeOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.D
 	for _, volume := range output.Volumes {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(volume)
+		attrs, err = sources.ToAttributesCase(volume, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/vpc.go
+++ b/sources/ec2/vpc.go
@@ -27,7 +27,7 @@ func vpcOutputMapper(_ context.Context, _ *ec2.Client, scope string, _ *ec2.Desc
 	for _, vpc := range output.Vpcs {
 		var err error
 		var attrs *sdp.ItemAttributes
-		attrs, err = sources.ToAttributesCase(vpc)
+		attrs, err = sources.ToAttributesCase(vpc, "tags")
 
 		if err != nil {
 			return nil, &sdp.QueryError{

--- a/sources/ec2/vpc_peering_connection.go
+++ b/sources/ec2/vpc_peering_connection.go
@@ -14,7 +14,7 @@ func vpcPeeringConnectionOutputMapper(_ context.Context, _ *ec2.Client, scope st
 	items := make([]*sdp.Item, 0)
 
 	for _, connection := range output.VpcPeeringConnections {
-		attributes, err := sources.ToAttributesCase(connection)
+		attributes, err := sources.ToAttributesCase(connection, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/ecs/capacity_provider.go
+++ b/sources/ecs/capacity_provider.go
@@ -19,7 +19,7 @@ func capacityProviderOutputMapper(_ context.Context, _ ECSClient, scope string, 
 	items := make([]*sdp.Item, 0)
 
 	for _, provider := range output.CapacityProviders {
-		attributes, err := sources.ToAttributesCase(provider)
+		attributes, err := sources.ToAttributesCase(provider, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/ecs/cluster.go
+++ b/sources/ecs/cluster.go
@@ -54,7 +54,7 @@ func clusterGetFunc(ctx context.Context, client ECSClient, scope string, input *
 
 	cluster := out.Clusters[0]
 
-	attributes, err := sources.ToAttributesCase(cluster)
+	attributes, err := sources.ToAttributesCase(cluster, "tags")
 
 	if err != nil {
 		return nil, err

--- a/sources/ecs/container_instance.go
+++ b/sources/ecs/container_instance.go
@@ -31,7 +31,7 @@ func containerInstanceGetFunc(ctx context.Context, client ECSClient, scope strin
 
 	containerInstance := out.ContainerInstances[0]
 
-	attributes, err := sources.ToAttributesCase(containerInstance)
+	attributes, err := sources.ToAttributesCase(containerInstance, "tags")
 
 	if err != nil {
 		return nil, err

--- a/sources/ecs/service.go
+++ b/sources/ecs/service.go
@@ -43,7 +43,7 @@ func serviceGetFunc(ctx context.Context, client ECSClient, scope string, input *
 
 	service.TaskSets = []types.TaskSet{}
 
-	attributes, err := sources.ToAttributesCase(service)
+	attributes, err := sources.ToAttributesCase(service, "tags")
 
 	if err != nil {
 		return nil, err

--- a/sources/ecs/task.go
+++ b/sources/ecs/task.go
@@ -31,7 +31,7 @@ func taskGetFunc(ctx context.Context, client ECSClient, scope string, input *ecs
 
 	task := out.Tasks[0]
 
-	attributes, err := sources.ToAttributesCase(task)
+	attributes, err := sources.ToAttributesCase(task, "tags")
 
 	if err != nil {
 		return nil, err

--- a/sources/efs/access_point.go
+++ b/sources/efs/access_point.go
@@ -19,7 +19,7 @@ func AccessPointOutputMapper(_ context.Context, _ *efs.Client, scope string, inp
 	items := make([]*sdp.Item, 0)
 
 	for _, ap := range output.AccessPoints {
-		attrs, err := sources.ToAttributesCase(ap)
+		attrs, err := sources.ToAttributesCase(ap, "tags")
 
 		if err != nil {
 			return nil, err

--- a/sources/efs/file_system.go
+++ b/sources/efs/file_system.go
@@ -19,7 +19,7 @@ func FileSystemOutputMapper(_ context.Context, _ *efs.Client, scope string, inpu
 	items := make([]*sdp.Item, 0)
 
 	for _, fs := range output.FileSystems {
-		attrs, err := sources.ToAttributesCase(fs)
+		attrs, err := sources.ToAttributesCase(fs, "tags")
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Now that we return them as a first-class citizen, we don't need to duplicate them in the attributes