### PR TITLE
ensure that `client.DescribeTags` is always called with data

### DIFF
--- a/sources/elb/elb.go
+++ b/sources/elb/elb.go
@@ -31,28 +31,27 @@ func loadBalancerOutputMapper(ctx context.Context, client elbClient, scope strin
 	items := make([]*sdp.Item, 0)
 
 	loadBalancerNames := make([]string, 0)
-
 	for _, desc := range output.LoadBalancerDescriptions {
 		if desc.LoadBalancerName != nil {
 			loadBalancerNames = append(loadBalancerNames, *desc.LoadBalancerName)
 		}
 	}
 
-	// Get all tags for all load balancers in this output
-	tagsOut, err := client.DescribeTags(ctx, &elb.DescribeTagsInput{
-		LoadBalancerNames: loadBalancerNames,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
 	// Map of load balancer name to tags
 	tagsMap := make(map[string][]types.Tag)
+	if len(loadBalancerNames) > 0 {
+		// Get all tags for all load balancers in this output
+		tagsOut, err := client.DescribeTags(ctx, &elb.DescribeTagsInput{
+			LoadBalancerNames: loadBalancerNames,
+		})
+		if err != nil {
+			return nil, err
+		}
 
-	for _, tagDesc := range tagsOut.TagDescriptions {
-		if tagDesc.LoadBalancerName != nil {
-			tagsMap[*tagDesc.LoadBalancerName] = tagDesc.Tags
+		for _, tagDesc := range tagsOut.TagDescriptions {
+			if tagDesc.LoadBalancerName != nil {
+				tagsMap[*tagDesc.LoadBalancerName] = tagDesc.Tags
+			}
 		}
 	}
 

--- a/sources/elbv2/shared.go
+++ b/sources/elbv2/shared.go
@@ -31,17 +31,18 @@ func tagsToMap(tags []types.Tag) map[string]string {
 func getTagsMap(ctx context.Context, client elbClient, arns []string) (map[string]map[string]string, error) {
 	tagsMap := make(map[string]map[string]string)
 
-	tagsOut, err := client.DescribeTags(ctx, &elbv2.DescribeTagsInput{
-		ResourceArns: arns,
-	})
+	if len(arns) > 0 {
+		tagsOut, err := client.DescribeTags(ctx, &elbv2.DescribeTagsInput{
+			ResourceArns: arns,
+		})
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return nil, err
-	}
-
-	for _, tagDescription := range tagsOut.TagDescriptions {
-		if tagDescription.ResourceArn != nil {
-			tagsMap[*tagDescription.ResourceArn] = tagsToMap(tagDescription.Tags)
+		for _, tagDescription := range tagsOut.TagDescriptions {
+			if tagDescription.ResourceArn != nil {
+				tagsMap[*tagDescription.ResourceArn] = tagsToMap(tagDescription.Tags)
+			}
 		}
 	}
 


### PR DESCRIPTION
`client.DescribeTags()` errors with `"operation error Elastic Load Balancing v2: DescribeTags, https response error StatusCode: 400, RequestID: 65fd5c40-98e3-451f-ac92-9b8b0b362ae9, api error ValidationError: An ARN must be specified"` when an empty array is passed as argument. This breaks fetching the rest of the item and related data.

This commit ensures this doesn't happen again.