### PR TITLE
ecs-service: provide a custom 404 when input is not properly defined

### DIFF
--- a/sources/ecs/service.go
+++ b/sources/ecs/service.go
@@ -18,6 +18,12 @@ var ServiceIncludeFields = []types.ServiceField{
 }
 
 func serviceGetFunc(ctx context.Context, client ECSClient, scope string, input *ecs.DescribeServicesInput) (*sdp.Item, error) {
+	if input == nil {
+		return nil, &sdp.QueryError{
+			ErrorType:   sdp.QueryError_NOTFOUND,
+			ErrorString: "no input provided",
+		}
+	}
 	out, err := client.DescribeServices(ctx, input)
 
 	if err != nil {


### PR DESCRIPTION
This could e.g. happen when the GetInputMapper doesn't find two sections