### PR TITLE
Add required metadata and git to the builder

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -80,8 +80,9 @@ jobs:
             image_name: aws-source
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # also fetch tags and branches for `git describe`
 
       - name: Docker meta
         id: meta

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.22-alpine3.18 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
+# required for generating the version descriptor
+RUN apk add --no-cache git
+
 WORKDIR /workspace
 
 # Copy the Go Modules manifests


### PR DESCRIPTION
this is used in `go generate` to create the commit.txt so the service knows its version