### PR TITLE
maint: reduce binary size in docker image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg \
     --mount=type=cache,target=/root/.cache/go-build \
     go generate ./... \
-    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o source main.go
+    && GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-s -w" -trimpath -o source main.go
 
 FROM alpine:3.20
 WORKDIR /


### PR DESCRIPTION
RE https://github.com/overmindtech/deploy/issues/868

/workspace/aws-source
```bash
go build -ldflags="-s -w" -trimpath -o small main.go
go build -o big main.go
-rwxr-xr-x 1 vscode vscode 133M Jul  1 13:09 big
-rwxr-xr-x 1 vscode vscode  98M Jul  1 13:08 small
```