### PR TITLE
add integration tests for ec2 instance and networkmanager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gopkg.lock
 build/compiled
 .idea
 commit.txt
+.envrc

--- a/go.mod
+++ b/go.mod
@@ -113,3 +113,5 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+require github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.21.7

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/aws/aws-sdk-go-v2/service/networkmanager v1.29.1 h1:t1i4NDFo2y5Hg8Bwn
 github.com/aws/aws-sdk-go-v2/service/networkmanager v1.29.1/go.mod h1:S65BWVUFuMME9yO5OTALY7zhdjwyl3uvCLdiv0qZ/w4=
 github.com/aws/aws-sdk-go-v2/service/rds v1.81.2 h1:8hS1TW26euZk4OZtZEYFDLGJ+8MDFRjtKLUBdLFbB64=
 github.com/aws/aws-sdk-go-v2/service/rds v1.81.2/go.mod h1:EuF7sZqyUlv+NPw1x2hz0XZDrKfqnSh0qHA84xJ3Unw=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.21.7 h1:1KTeOEqOwS+eYuiqYhkiWV+4Fmet/vBkPCt/5dxZVsg=
+github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.21.7/go.mod h1:I3uJLgoT83sDh9YRQdcUDoauftf7ySq9hFB7Z6O7p2c=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.42.1 h1:nsqHenlmW2rjUgMTiA58YhVAEooFA4IaXdzB6Y7WOpc=
 github.com/aws/aws-sdk-go-v2/service/route53 v1.42.1/go.mod h1:FL7amoKYyP0gYGOvg2ea5kGW5mh0NsBS9AGWR11LMVo=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.58.0 h1:4rhV0Hn+bf8IAIUphRX1moBcEvKJipCPmswMCl6Q5mw=

--- a/proc/proc.go
+++ b/proc/proc.go
@@ -415,17 +415,11 @@ func InitializeAwsSourceEngine(ctx context.Context, natsOptions auth.NATSOptions
 
 				// Network Manager
 				networkmanager.NewConnectAttachmentSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewConnectionSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewConnectPeerAssociationSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewConnectPeerSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewCoreNetworkPolicySource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewCoreNetworkSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewDeviceSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewGlobalNetworkSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewLinkAssociationSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewLinkSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewNetworkResourceRelationshipsSource(networkmanagerClient, *callerID.Account, region),
-				networkmanager.NewSiteSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewSiteToSiteVpnAttachmentSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewTransitGatewayConnectPeerAssociationSource(networkmanagerClient, *callerID.Account, region),
 				networkmanager.NewTransitGatewayPeeringSource(networkmanagerClient, *callerID.Account, region),
@@ -466,6 +460,14 @@ func InitializeAwsSourceEngine(ctx context.Context, natsOptions auth.NATSOptions
 
 					// S3
 					s3.NewS3Source(cfg, *callerID.Account),
+
+					// Networkmanager
+					networkmanager.NewGlobalNetworkSource(networkmanagerClient, *callerID.Account),
+					networkmanager.NewSiteSource(networkmanagerClient, *callerID.Account),
+					networkmanager.NewLinkSource(networkmanagerClient, *callerID.Account),
+					networkmanager.NewDeviceSource(networkmanagerClient, *callerID.Account),
+					networkmanager.NewLinkAssociationSource(networkmanagerClient, *callerID.Account),
+					networkmanager.NewConnectionSource(networkmanagerClient, *callerID.Account),
 				)
 			}
 			return nil

--- a/sources/ecs/integration/integration.go
+++ b/sources/ecs/integration/integration.go
@@ -1,0 +1,21 @@
+package integration
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+func Setup() error {
+	fmt.Println("Setting up ECS integration tests")
+	return nil
+}
+
+func Teardown(logger *slog.Logger) error {
+	logger.Info("Tearing down ECS integration tests")
+	return nil
+}
+
+func TestServiceSource(logger *slog.Logger) error {
+	logger.Info("Running ECS integration test TestServiceSource")
+	return nil
+}

--- a/sources/efs/integration/integration_test.go
+++ b/sources/efs/integration/integration_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func Setup() error {
+	fmt.Println("Setting up EFS integration tests")
+	return nil
+}
+
+func Teardown(logger *slog.Logger) error {
+	logger.Info("Tearing down EFS integration tests")
+	return nil
+}
+
+func TestIntegrationEFSSomeSource(t *testing.T) {
+	slog.Info("Running EFS integration test TestSomeSource")
+}
+
+func TestMain(m *testing.M) {
+	if !shouldRunIntegrationTests() {
+		slog.Warn("skipping integration tests.. set RUN_ALL_INTEGRATION_TESTS=true or individual RUN_EFS_INTEGRATION_TESTS=true to run them")
+		os.Exit(0)
+	}
+
+	err := Setup()
+	if err != nil {
+		slog.Error("failed to setup integration test environment", "err", err)
+		os.Exit(1)
+	}
+
+	slog.Info("Completed setup")
+
+	code := m.Run()
+	if code != 0 {
+		slog.Warn("integration tests failed", "code", code)
+	} else {
+		slog.Info("integration tests passed", "code", code)
+	}
+
+	slog.Info("Running teardown")
+	if err := Teardown(slog.Default()); err != nil {
+		slog.Error("failed to teardown integration test environment", "err", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+// this can be in a more general package
+func shouldRunIntegrationTests() bool {
+	runAll, found := os.LookupEnv("RUN_ALL_INTEGRATION_TESTS")
+	if found {
+		shouldRunAll, err := strconv.ParseBool(runAll)
+		if err != nil {
+			return false
+		}
+
+		if shouldRunAll {
+			return true
+		}
+	}
+
+	runEFS, found := os.LookupEnv("RUN_EFS_INTEGRATION_TESTS")
+	if found {
+		shouldRunEFS, err := strconv.ParseBool(runEFS)
+		if err != nil {
+			return false
+		}
+
+		if shouldRunEFS {
+			return true
+		}
+	}
+
+	return false
+}

--- a/sources/eks/integration/integration_test.go
+++ b/sources/eks/integration/integration_test.go
@@ -1,0 +1,82 @@
+package integration
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func Setup() error {
+	fmt.Println("Setting up EKS integration tests")
+	return nil
+}
+
+func Teardown(logger *slog.Logger) error {
+	logger.Info("Tearing down EKS integration tests")
+	return nil
+}
+
+func TestIntegrationEKSSomeSource(t *testing.T) {
+	slog.Info("Running EKS integration test TestSomeSource")
+}
+
+func TestMain(m *testing.M) {
+	if !shouldRunIntegrationTests() {
+		slog.Warn("skipping integration tests.. set RUN_ALL_INTEGRATION_TESTS=true or individual RUN_EKS_INTEGRATION_TESTS=true to run them")
+		os.Exit(0)
+	}
+
+	err := Setup()
+	if err != nil {
+		slog.Error("failed to setup integration test environment", "err", err)
+		os.Exit(1)
+	}
+
+	slog.Info("Completed setup")
+
+	code := m.Run()
+	if code != 0 {
+		slog.Warn("integration tests failed", "code", code)
+	} else {
+		slog.Info("integration tests passed", "code", code)
+	}
+
+	slog.Info("Running teardown")
+	if err := Teardown(slog.Default()); err != nil {
+		slog.Error("failed to teardown integration test environment", "err", err)
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+// this can be in a more general package
+func shouldRunIntegrationTests() bool {
+	runAll, found := os.LookupEnv("RUN_ALL_INTEGRATION_TESTS")
+	if found {
+		shouldRunAll, err := strconv.ParseBool(runAll)
+		if err != nil {
+			return false
+		}
+
+		if shouldRunAll {
+			return true
+		}
+	}
+
+	runEFS, found := os.LookupEnv("RUN_EKS_INTEGRATION_TESTS")
+	if found {
+		shouldRunEFS, err := strconv.ParseBool(runEFS)
+		if err != nil {
+			return false
+		}
+
+		if shouldRunEFS {
+			return true
+		}
+	}
+
+	return false
+}

--- a/sources/integration/ec2/create.go
+++ b/sources/integration/ec2/create.go
@@ -1,0 +1,62 @@
+package ec2
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func createEC2Instance(ctx context.Context, logger *slog.Logger, client *ec2.Client, testID string) error {
+	// check if a resource with the same tags already exists
+	id, err := findActiveInstanceIDByTags(client)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating EC2 instance")
+		} else {
+			return err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "EC2 instance already exists")
+		return nil
+	}
+
+	input := &ec2.RunInstancesInput{
+		DryRun: aws.Bool(false),
+		// `Subscribe Now` is selected on marketplace UI
+		ImageId:      aws.String("ami-022667efd26192f0b"), // openSUSE Leap 15.2
+		InstanceType: types.InstanceTypeT3Nano,
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		TagSpecifications: []types.TagSpecification{
+			{
+				ResourceType: types.ResourceTypeInstance,
+				// TODO: Create a convenience function to add shared tags to the resources
+				Tags: resourceTags(instanceSrc, testID),
+			},
+		},
+	}
+
+	result, err := client.RunInstances(context.Background(), input)
+	if err != nil {
+		return err
+	}
+
+	waiter := ec2.NewInstanceRunningWaiter(client)
+	err = waiter.Wait(context.Background(), &ec2.DescribeInstancesInput{
+		InstanceIds: []string{*result.Instances[0].InstanceId},
+	},
+		5*time.Minute)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sources/integration/ec2/delete.go
+++ b/sources/integration/ec2/delete.go
@@ -1,0 +1,16 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+func deleteInstance(ctx context.Context, client *ec2.Client, instanceID string) error {
+	input := &ec2.TerminateInstancesInput{
+		InstanceIds: []string{instanceID},
+	}
+
+	_, err := client.TerminateInstances(ctx, input)
+	return err
+}

--- a/sources/integration/ec2/find.go
+++ b/sources/integration/ec2/find.go
@@ -1,0 +1,36 @@
+package ec2
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+// findActiveInstanceIDByTags finds an instance by tags
+// additionalAttr is a variadic parameter that allows to specify additional attributes to search for
+// it ignores terminated instances
+func findActiveInstanceIDByTags(client *ec2.Client, additionalAttr ...string) (*string, error) {
+	result, err := client.DescribeInstances(context.Background(), &ec2.DescribeInstancesInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, reservation := range result.Reservations {
+		for _, instance := range reservation.Instances {
+			// ignore terminated or shutting down instances
+			if instance.State.Name == types.InstanceStateNameTerminated ||
+				instance.State.Name == types.InstanceStateNameShuttingDown {
+				// ignore terminated instances
+				continue
+			}
+
+			if hasTags(instance.Tags, resourceTags(instanceSrc, integration.TestID(), additionalAttr...)) {
+				return instance.InstanceId, nil
+			}
+		}
+	}
+
+	return nil, integration.NewNotFoundError(integration.ResourceName(integration.EC2, instanceSrc, additionalAttr...))
+}

--- a/sources/integration/ec2/instance_test.go
+++ b/sources/integration/ec2/instance_test.go
@@ -1,0 +1,101 @@
+package ec2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/overmindtech/aws-source/sources"
+	"github.com/overmindtech/aws-source/sources/ec2"
+	"github.com/overmindtech/aws-source/sources/integration"
+	"github.com/overmindtech/sdp-go"
+)
+
+func TestEC2(t *testing.T) {
+	ctx := context.Background()
+
+	t.Log("Running EC2 integration test")
+
+	ec2Cli, err := createEC2Client(ctx)
+	if err != nil {
+		t.Fatalf("failed to create EC2 client: %v", err)
+	}
+
+	awsCfg, err := integration.AWSSettings(ctx)
+	if err != nil {
+		t.Fatalf("failed to get AWS settings: %v", err)
+	}
+
+	instanceSource := ec2.NewInstanceSource(ec2Cli, awsCfg.AccountID, awsCfg.Region)
+
+	err = instanceSource.Validate()
+	if err != nil {
+		t.Fatalf("failed to validate EC2 instance source: %v", err)
+	}
+
+	scope := sources.FormatScope(awsCfg.AccountID, awsCfg.Region)
+
+	// List instances
+	sdpListInstances, err := instanceSource.List(context.Background(), scope, true)
+	if err != nil {
+		t.Fatalf("failed to list EC2 instances: %v", err)
+	}
+
+	if len(sdpListInstances) == 0 {
+		t.Fatalf("no instances found")
+	}
+
+	uniqueAttribute := sdpListInstances[0].GetUniqueAttribute()
+
+	instanceID, err := integration.GetUniqueAttributeValue(
+		uniqueAttribute,
+		sdpListInstances,
+		integration.ResourceTags(integration.EC2, instanceSrc),
+	)
+	if err != nil {
+		t.Fatalf("failed to get instance ID: %v", err)
+	}
+
+	// Get instance
+	sdpInstance, err := instanceSource.Get(context.Background(), scope, instanceID, true)
+	if err != nil {
+		t.Fatalf("failed to get EC2 instance: %v", err)
+	}
+
+	instanceIDFromGet, err := integration.GetUniqueAttributeValue(
+		uniqueAttribute,
+		[]*sdp.Item{sdpInstance},
+		integration.ResourceTags(integration.EC2, instanceSrc),
+	)
+	if err != nil {
+		t.Fatalf("failed to get instance ID from get: %v", err)
+	}
+
+	if instanceIDFromGet != instanceID {
+		t.Fatalf("expected instance ID %v, got %v", instanceID, instanceIDFromGet)
+	}
+
+	// Search instances
+	instanceARN := fmt.Sprintf("arn:aws:ec2:%s:%s:instance/%s", awsCfg.Region, awsCfg.AccountID, instanceID)
+	sdpSearchInstances, err := instanceSource.Search(context.Background(), scope, instanceARN, true)
+	if err != nil {
+		t.Fatalf("failed to search EC2 instances: %v", err)
+	}
+
+	if len(sdpSearchInstances) == 0 {
+		t.Fatalf("no instances found")
+	}
+
+	instanceIDFromSearch, err := integration.GetUniqueAttributeValue(
+		uniqueAttribute,
+		sdpSearchInstances,
+		integration.ResourceTags(integration.EC2, instanceSrc),
+	)
+	if err != nil {
+		t.Fatalf("failed to get instance ID from search: %v", err)
+	}
+
+	if instanceIDFromSearch != instanceID {
+		t.Fatalf("expected instance ID %v, got %v", instanceID, instanceIDFromSearch)
+	}
+}

--- a/sources/integration/ec2/main_test.go
+++ b/sources/integration/ec2/main_test.go
@@ -1,0 +1,57 @@
+package ec2
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func TestMain(m *testing.M) {
+	if integration.ShouldRunIntegrationTests() {
+		fmt.Println("Running integration tests")
+		os.Exit(m.Run())
+	} else {
+		fmt.Println("Skipping integration tests, set RUN_INTEGRATION_TESTS=true to run them")
+		os.Exit(0)
+	}
+}
+
+func TestIntegrationEC2(t *testing.T) {
+	TestSetup(t)
+
+	TestEC2(t)
+
+	TestTeardown(t)
+}
+
+func TestSetup(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	ec2Client, err := createEC2Client(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create EC2 client: %v", err)
+	}
+
+	if err := setup(ctx, logger, ec2Client); err != nil {
+		t.Fatalf("Failed to setup EC2 integration tests: %v", err)
+	}
+}
+
+func TestTeardown(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	ec2Client, err := createEC2Client(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create EC2 client: %v", err)
+	}
+
+	if err := teardown(ctx, logger, ec2Client); err != nil {
+		t.Fatalf("Failed to teardown EC2 integration tests: %v", err)
+	}
+}

--- a/sources/integration/ec2/setup.go
+++ b/sources/integration/ec2/setup.go
@@ -1,0 +1,27 @@
+package ec2
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+const instanceSrc = "instance"
+
+func setup(ctx context.Context, logger *slog.Logger, client *ec2.Client) error {
+	// Create EC2 instance
+	return createEC2Instance(ctx, logger, client, integration.TestID())
+}
+
+func createEC2Client(ctx context.Context) (*ec2.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client := ec2.NewFromConfig(cfg)
+	return client, nil
+}

--- a/sources/integration/ec2/teardown.go
+++ b/sources/integration/ec2/teardown.go
@@ -1,0 +1,25 @@
+package ec2
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func teardown(ctx context.Context, logger *slog.Logger, client *ec2.Client) error {
+	instanceID, err := findActiveInstanceIDByTags(client)
+	if err != nil {
+		nf := integration.NewNotFoundError(instanceSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Instance not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	return deleteInstance(ctx, client, *instanceID)
+}

--- a/sources/integration/ec2/util.go
+++ b/sources/integration/ec2/util.go
@@ -1,0 +1,48 @@
+package ec2
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func resourceTags(resourceName, testID string, nameAdditionalAttr ...string) []types.Tag {
+	return []types.Tag{
+		{
+			Key:   aws.String(integration.TagTestKey),
+			Value: aws.String(integration.TagTestValue),
+		},
+		{
+			Key:   aws.String(integration.TagTestTypeKey),
+			Value: aws.String(integration.TestName(integration.EC2)),
+		},
+		{
+			Key:   aws.String(integration.TagTestIDKey),
+			Value: aws.String(testID),
+		},
+		{
+			Key:   aws.String(integration.TagResourceIDKey),
+			Value: aws.String(integration.ResourceName(integration.EC2, resourceName, nameAdditionalAttr...)),
+		},
+	}
+}
+
+func hasTags(tags []types.Tag, requiredTags []types.Tag) bool {
+	rT := make(map[string]string)
+	for _, t := range requiredTags {
+		rT[*t.Key] = *t.Value
+	}
+
+	oT := make(map[string]string)
+	for _, t := range tags {
+		oT[*t.Key] = *t.Value
+	}
+
+	for k, v := range rT {
+		if oT[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/sources/integration/errors.go
+++ b/sources/integration/errors.go
@@ -1,0 +1,15 @@
+package integration
+
+import "fmt"
+
+type NotFoundError struct {
+	ResourceName string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("Resource not found: %s", e.ResourceName)
+}
+
+func NewNotFoundError(resourceName string) NotFoundError {
+	return NotFoundError{ResourceName: resourceName}
+}

--- a/sources/integration/networkmanager/create.go
+++ b/sources/integration/networkmanager/create.go
@@ -1,0 +1,198 @@
+package networkmanager
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func createGlobalNetwork(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, testID string) (*string, error) {
+	tags := resourceTags(globalNetworkSrc, testID)
+
+	id, err := findGlobalNetworkIDByTags(ctx, client, tags)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating global network")
+		} else {
+			return nil, err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Global network already exists")
+		return id, nil
+	}
+
+	input := &networkmanager.CreateGlobalNetworkInput{
+		Description: aws.String("Integration test global network"),
+		Tags:        tags,
+	}
+
+	response, err := client.CreateGlobalNetwork(context.Background(), input)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.GlobalNetwork.GlobalNetworkId, nil
+}
+
+func createSite(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, testID string, globalNetworkID *string) (*string, error) {
+	tags := resourceTags(siteSrc, testID)
+
+	id, err := findSiteIDByTags(ctx, client, globalNetworkID, tags)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating site")
+		} else {
+			return nil, err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Site already exists")
+		return id, nil
+	}
+
+	input := &networkmanager.CreateSiteInput{
+		GlobalNetworkId: globalNetworkID,
+		Description:     aws.String("Integration test site"),
+		Tags:            tags,
+	}
+
+	response, err := client.CreateSite(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Site.SiteId, nil
+}
+
+func createLink(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, testID string, globalNetworkID, siteID *string) (*string, error) {
+	tags := resourceTags(linkSrc, testID)
+
+	id, err := findLinkIDByTags(ctx, client, globalNetworkID, siteID, tags)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating link")
+		} else {
+			return nil, err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Link already exists")
+		return id, nil
+	}
+
+	input := &networkmanager.CreateLinkInput{
+		GlobalNetworkId: globalNetworkID,
+		SiteId:          siteID,
+		Description:     aws.String("Integration test link"),
+		Bandwidth: &types.Bandwidth{
+			UploadSpeed:   aws.Int32(50),
+			DownloadSpeed: aws.Int32(50),
+		},
+		Tags: tags,
+	}
+
+	response, err := client.CreateLink(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Link.LinkId, nil
+}
+
+func createDevice(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, testID string, globalNetworkID, siteID *string, deviceName string) (*string, error) {
+	tags := resourceTags(deviceSrc, testID, deviceName)
+
+	id, err := findDeviceIDByTags(ctx, client, globalNetworkID, siteID, tags)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating device", "name", deviceName)
+		} else {
+			return nil, err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Device already exists", "name", deviceName)
+		return id, nil
+	}
+
+	input := &networkmanager.CreateDeviceInput{
+		GlobalNetworkId: globalNetworkID,
+		SiteId:          siteID,
+		Tags:            tags,
+	}
+
+	response, err := client.CreateDevice(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.Device.DeviceId, nil
+}
+
+func createLinkAssociation(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, globalNetworkID, deviceID, linkID *string) error {
+	id, err := findLinkAssociationID(ctx, client, globalNetworkID, linkID, deviceID)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating link association")
+		} else {
+			return err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Link association already exists")
+		return nil
+	}
+
+	input := &networkmanager.AssociateLinkInput{
+		DeviceId:        deviceID,
+		GlobalNetworkId: globalNetworkID,
+		LinkId:          linkID,
+	}
+
+	_, err = client.AssociateLink(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createConnection(ctx context.Context, logger *slog.Logger, client *networkmanager.Client, globalNetworkID, deviceID, connectedDeviceID *string) error {
+	id, err := findConnectionID(ctx, client, globalNetworkID, deviceID)
+	if err != nil {
+		if errors.As(err, new(integration.NotFoundError)) {
+			logger.InfoContext(ctx, "Creating connection")
+		} else {
+			return err
+		}
+	}
+
+	if id != nil {
+		logger.InfoContext(ctx, "Connection already exists")
+		return nil
+	}
+
+	input := &networkmanager.CreateConnectionInput{
+		GlobalNetworkId:   globalNetworkID,
+		DeviceId:          deviceID,
+		ConnectedDeviceId: connectedDeviceID,
+	}
+
+	_, err = client.CreateConnection(ctx, input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sources/integration/networkmanager/delete.go
+++ b/sources/integration/networkmanager/delete.go
@@ -1,0 +1,135 @@
+package networkmanager
+
+import (
+	"context"
+	"errors"
+
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
+	"github.com/aws/smithy-go"
+	"github.com/overmindtech/aws-source/sources/integration"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
+)
+
+func deleteGlobalNetwork(ctx context.Context, client *networkmanager.Client, globalNetworkID string) error {
+	input := &networkmanager.DeleteGlobalNetworkInput{
+		GlobalNetworkId: aws.String(globalNetworkID),
+	}
+
+	_, err := client.DeleteGlobalNetwork(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, globalNetworkSrc))
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteSite(ctx context.Context, client *networkmanager.Client, globalNetworkID, siteID *string) error {
+	input := &networkmanager.DeleteSiteInput{
+		GlobalNetworkId: globalNetworkID,
+		SiteId:          siteID,
+	}
+
+	_, err := client.DeleteSite(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, siteSrc))
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteLink(ctx context.Context, client *networkmanager.Client, globalNetworkID, linkID *string) error {
+	input := &networkmanager.DeleteLinkInput{
+		GlobalNetworkId: globalNetworkID,
+		LinkId:          linkID,
+	}
+
+	_, err := client.DeleteLink(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, linkSrc))
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func deleteDevice(ctx context.Context, client *networkmanager.Client, globalNetworkID, deviceID *string) error {
+	input := &networkmanager.DeleteDeviceInput{
+		GlobalNetworkId: globalNetworkID,
+		DeviceId:        deviceID,
+	}
+
+	_, err := client.DeleteDevice(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, deviceSrc))
+		} else {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func deleteLinkAssociation(ctx context.Context, client *networkmanager.Client, globalNetworkID, deviceID, linkID *string) error {
+	input := &networkmanager.DisassociateLinkInput{
+		GlobalNetworkId: globalNetworkID,
+		DeviceId:        deviceID,
+		LinkId:          linkID,
+	}
+
+	_, err := client.DisassociateLink(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, linkAssociationSrc))
+		} else {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func deleteConnection(ctx context.Context, client *networkmanager.Client, globalNetworkID, connectionID *string) error {
+	input := &networkmanager.DeleteConnectionInput{
+		GlobalNetworkId: globalNetworkID,
+		ConnectionId:    connectionID,
+	}
+
+	_, err := client.DeleteConnection(ctx, input)
+	if err != nil {
+		var apiErr smithy.APIError
+		notFoundException := types.ResourceNotFoundException{}
+		if errors.As(err, &apiErr) && apiErr.ErrorCode() == notFoundException.ErrorCode() {
+			return integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, connectionSrc))
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/sources/integration/networkmanager/find.go
+++ b/sources/integration/networkmanager/find.go
@@ -1,0 +1,121 @@
+package networkmanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func findGlobalNetworkIDByTags(ctx context.Context, client *networkmanager.Client, requiredTags []types.Tag) (*string, error) {
+	result, err := client.DescribeGlobalNetworks(ctx, &networkmanager.DescribeGlobalNetworksInput{})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, globalNetwork := range result.GlobalNetworks {
+		if hasTags(globalNetwork.Tags, requiredTags) {
+			return globalNetwork.GlobalNetworkId, nil
+		}
+	}
+
+	return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, globalNetworkSrc))
+}
+
+func findSiteIDByTags(ctx context.Context, client *networkmanager.Client, globalNetworkID *string, requiredTags []types.Tag) (*string, error) {
+	result, err := client.GetSites(ctx, &networkmanager.GetSitesInput{
+		GlobalNetworkId: globalNetworkID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, site := range result.Sites {
+		if hasTags(site.Tags, requiredTags) {
+			return site.SiteId, nil
+		}
+	}
+
+	return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, siteSrc))
+}
+
+func findLinkIDByTags(ctx context.Context, client *networkmanager.Client, globalNetworkID, siteID *string, requiredTags []types.Tag) (*string, error) {
+	result, err := client.GetLinks(ctx, &networkmanager.GetLinksInput{
+		GlobalNetworkId: globalNetworkID,
+		SiteId:          siteID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, link := range result.Links {
+		if hasTags(link.Tags, requiredTags) {
+			return link.LinkId, nil
+		}
+	}
+
+	return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, linkSrc))
+}
+
+func findDeviceIDByTags(ctx context.Context, client *networkmanager.Client, globalNetworkID, sideID *string, requiredTags []types.Tag) (*string, error) {
+	result, err := client.GetDevices(ctx, &networkmanager.GetDevicesInput{
+		GlobalNetworkId: globalNetworkID,
+		SiteId:          sideID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, device := range result.Devices {
+		if hasTags(device.Tags, requiredTags) {
+			return device.DeviceId, nil
+		}
+	}
+
+	return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, deviceSrc))
+}
+
+func findLinkAssociationID(ctx context.Context, client *networkmanager.Client, globalNetworkID, linkID, deviceID *string) (*string, error) {
+	result, err := client.GetLinkAssociations(ctx, &networkmanager.GetLinkAssociationsInput{
+		GlobalNetworkId: globalNetworkID,
+		LinkId:          linkID,
+		DeviceId:        deviceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.LinkAssociations) != 1 {
+		if len(result.LinkAssociations) == 0 {
+			return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, linkAssociationSrc))
+		}
+
+		return nil, fmt.Errorf("expected 1 link association, got %d", len(result.LinkAssociations))
+	}
+
+	compositeKey := fmt.Sprintf("%s|%s|%s", *globalNetworkID, *linkID, *deviceID)
+
+	return &compositeKey, nil
+}
+
+func findConnectionID(ctx context.Context, client *networkmanager.Client, globalNetworkID, deviceID *string) (*string, error) {
+	result, err := client.GetConnections(ctx, &networkmanager.GetConnectionsInput{
+		GlobalNetworkId: globalNetworkID,
+		DeviceId:        deviceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(result.Connections) != 1 {
+		if len(result.Connections) == 0 {
+			return nil, integration.NewNotFoundError(integration.ResourceName(integration.NetworkManager, connectionSrc))
+		}
+
+		return nil, fmt.Errorf("expected 1 connection, got %d", len(result.Connections))
+	}
+
+	return result.Connections[0].ConnectionId, nil
+}

--- a/sources/integration/networkmanager/main_test.go
+++ b/sources/integration/networkmanager/main_test.go
@@ -1,0 +1,57 @@
+package networkmanager
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func TestMain(m *testing.M) {
+	if integration.ShouldRunIntegrationTests() {
+		fmt.Println("Running integration tests")
+		os.Exit(m.Run())
+	} else {
+		fmt.Println("Skipping integration tests, set RUN_INTEGRATION_TESTS=true to run them")
+		os.Exit(0)
+	}
+}
+
+func TestIntegrationNetworkManager(t *testing.T) {
+	TestSetup(t)
+
+	TestNetworkManager(t)
+
+	TestTeardown(t)
+}
+
+func TestSetup(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	networkmanagerClient, err := createNetworkManagerClient(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create NetworkManager client: %v", err)
+	}
+
+	if err := setup(ctx, logger, networkmanagerClient); err != nil {
+		t.Fatalf("Failed to setup NetworkManager integration tests: %v", err)
+	}
+}
+
+func TestTeardown(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.Default()
+
+	networkmanagerClient, err := createNetworkManagerClient(ctx)
+	if err != nil {
+		t.Fatalf("Failed to create NetworkManager client: %v", err)
+	}
+
+	if err := teardown(ctx, logger, networkmanagerClient); err != nil {
+		t.Fatalf("Failed to teardown NetworkManager integration tests: %v", err)
+	}
+}

--- a/sources/integration/networkmanager/networkmanager_test.go
+++ b/sources/integration/networkmanager/networkmanager_test.go
@@ -1,0 +1,383 @@
+package networkmanager
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/overmindtech/aws-source/sources"
+	"github.com/overmindtech/aws-source/sources/integration"
+	"github.com/overmindtech/aws-source/sources/networkmanager"
+	"github.com/overmindtech/sdp-go"
+)
+
+func TestNetworkManager(t *testing.T) {
+	ctx := context.Background()
+
+	t.Logf("Running NetworkManager integration tests")
+
+	networkManagerCli, err := createNetworkManagerClient(ctx)
+	if err != nil {
+		t.Fatalf("failed to create NetworkManager client: %v", err)
+	}
+
+	awsCfg, err := integration.AWSSettings(ctx)
+	if err != nil {
+		t.Fatalf("failed to get AWS settings: %v", err)
+	}
+
+	globalNetworkSource := networkmanager.NewGlobalNetworkSource(networkManagerCli, awsCfg.AccountID)
+	if globalNetworkSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager global network source: %v", err)
+	}
+
+	siteSource := networkmanager.NewSiteSource(networkManagerCli, awsCfg.AccountID)
+	if siteSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager site source: %v", err)
+	}
+
+	linkSource := networkmanager.NewLinkSource(networkManagerCli, awsCfg.AccountID)
+	if linkSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager link source: %v", err)
+	}
+
+	linkAssociationSource := networkmanager.NewLinkAssociationSource(networkManagerCli, awsCfg.AccountID)
+	if linkAssociationSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager link association source: %v", err)
+	}
+
+	connectionSource := networkmanager.NewConnectionSource(networkManagerCli, awsCfg.AccountID)
+	if connectionSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager connection source: %v", err)
+	}
+
+	deviceSource := networkmanager.NewDeviceSource(networkManagerCli, awsCfg.AccountID)
+	if deviceSource.Validate() != nil {
+		t.Fatalf("failed to validate NetworkManager device source: %v", err)
+	}
+
+	globalScope := sources.FormatScope(awsCfg.AccountID, "")
+
+	t.Run("Global Network", func(t *testing.T) {
+		// List global networks
+		globalNetworks, err := globalNetworkSource.List(ctx, globalScope, true)
+		if err != nil {
+			t.Fatalf("failed to list NetworkManager global networks: %v", err)
+		}
+
+		if len(globalNetworks) == 0 {
+			t.Fatalf("no global networks found")
+		}
+
+		globalNetworkUniqueAttribute := globalNetworks[0].GetUniqueAttribute()
+
+		globalNetworkID, err := integration.GetUniqueAttributeValue(
+			globalNetworkUniqueAttribute,
+			globalNetworks,
+			integration.ResourceTags(integration.NetworkManager, globalNetworkSrc),
+		)
+		if err != nil {
+			t.Fatalf("failed to get global network ID: %v", err)
+		}
+
+		// Get global network
+		globalNetwork, err := globalNetworkSource.Get(ctx, globalScope, globalNetworkID, true)
+		if err != nil {
+			t.Fatalf("failed to get NetworkManager global network: %v", err)
+		}
+
+		globalNetworkIDFromGet, err := integration.GetUniqueAttributeValue(
+			globalNetworkUniqueAttribute,
+			[]*sdp.Item{globalNetwork},
+			integration.ResourceTags(integration.NetworkManager, globalNetworkSrc),
+		)
+		if err != nil {
+			t.Fatalf("failed to get global network ID from get: %v", err)
+		}
+
+		if globalNetworkID != globalNetworkIDFromGet {
+			t.Fatalf("expected global network ID %s, got %s", globalNetworkID, globalNetworkIDFromGet)
+		}
+
+		// Search global network by ARN
+		globalNetworkARN, err := globalNetwork.GetAttributes().Get("globalNetworkArn")
+		if err != nil {
+			t.Fatalf("failed to get global network ARN: %v", err)
+		}
+
+		if globalScope != globalNetwork.GetScope() {
+			t.Fatalf("expected global scope %s, got %s", globalScope, globalNetwork.GetScope())
+		}
+
+		globalNetworks, err = globalNetworkSource.Search(ctx, globalScope, globalNetworkARN.(string), true)
+		if err != nil {
+			t.Fatalf("failed to search NetworkManager global networks: %v", err)
+		}
+
+		if len(globalNetworks) == 0 {
+			t.Fatalf("no global networks found")
+		}
+
+		globalNetworkIDFromSearch, err := integration.GetUniqueAttributeValue(
+			globalNetworkUniqueAttribute,
+			globalNetworks,
+			integration.ResourceTags(integration.NetworkManager, globalNetworkSrc),
+		)
+		if err != nil {
+			t.Fatalf("failed to get global network ID from search: %v", err)
+		}
+
+		if globalNetworkID != globalNetworkIDFromSearch {
+			t.Fatalf("expected global network ID %s, got %s", globalNetworkID, globalNetworkIDFromSearch)
+		}
+
+		t.Run("Site", func(t *testing.T) {
+			// Search sites by the global network ID that they are created on
+			sites, err := siteSource.Search(ctx, globalScope, globalNetworkID, true)
+			if err != nil {
+				t.Fatalf("failed to search for site: %v", err)
+			}
+
+			if len(sites) == 0 {
+				t.Fatalf("no sites found")
+			}
+
+			siteUniqueAttribute := sites[0].GetUniqueAttribute()
+
+			// composite site id is in the format of {globalNetworkID}|{siteID}
+			compositeSiteID, err := integration.GetUniqueAttributeValue(
+				siteUniqueAttribute,
+				sites,
+				integration.ResourceTags(integration.NetworkManager, siteSrc),
+			)
+			if err != nil {
+				t.Fatalf("failed to get site ID from search: %v", err)
+			}
+
+			// Get site: query format = globalNetworkID|siteID
+			site, err := siteSource.Get(ctx, globalScope, compositeSiteID, true)
+			if err != nil {
+				t.Fatalf("failed to get site: %v", err)
+			}
+
+			siteIDFromGet, err := integration.GetUniqueAttributeValue(
+				siteUniqueAttribute,
+				[]*sdp.Item{site},
+				integration.ResourceTags(integration.NetworkManager, siteSrc),
+			)
+			if err != nil {
+				t.Fatalf("failed to get site ID from get: %v", err)
+			}
+
+			if compositeSiteID != siteIDFromGet {
+				t.Fatalf("expected site ID %s, got %s", compositeSiteID, siteIDFromGet)
+			}
+
+			siteID := strings.Split(compositeSiteID, "|")[1]
+
+			t.Run("Link", func(t *testing.T) {
+				// Search links by the global network ID that they are created on
+				links, err := linkSource.Search(ctx, globalScope, globalNetworkID, true)
+				if err != nil {
+					t.Fatalf("failed to search for link: %v", err)
+				}
+
+				if len(links) == 0 {
+					t.Fatalf("no links found")
+				}
+
+				linkUniqueAttribute := links[0].GetUniqueAttribute()
+
+				compositeLinkID, err := integration.GetUniqueAttributeValue(
+					linkUniqueAttribute,
+					links,
+					integration.ResourceTags(integration.NetworkManager, linkSrc),
+				)
+				if err != nil {
+					t.Fatalf("failed to get link ID from search: %v", err)
+				}
+
+				// Get link: query format = globalNetworkID|linkID
+				link, err := linkSource.Get(ctx, globalScope, compositeLinkID, true)
+				if err != nil {
+					t.Fatalf("failed to get link: %v", err)
+				}
+
+				linkIDFromGet, err := integration.GetUniqueAttributeValue(
+					linkUniqueAttribute,
+					[]*sdp.Item{link},
+					integration.ResourceTags(integration.NetworkManager, linkSrc),
+				)
+
+				if compositeLinkID != linkIDFromGet {
+					t.Fatalf("expected link ID %s, got %s", compositeLinkID, linkIDFromGet)
+				}
+
+				linkID := strings.Split(compositeLinkID, "|")[1]
+
+				t.Run("Device", func(t *testing.T) {
+					// Search devices by the global network ID and site ID
+					// query format = globalNetworkID|siteID
+					queryDevice := fmt.Sprintf("%s|%s", globalNetworkID, siteID)
+					devices, err := deviceSource.Search(ctx, globalScope, queryDevice, true)
+					if err != nil {
+						t.Fatalf("failed to search for device: %v", err)
+					}
+
+					if len(devices) == 0 {
+						t.Fatalf("no devices found")
+					}
+
+					deviceUniqueAttribute := devices[0].GetUniqueAttribute()
+
+					// composite device id is in the format of: {globalNetworkID}|{deviceID}
+					deviceOneCompositeID, err := integration.GetUniqueAttributeValue(
+						deviceUniqueAttribute,
+						devices,
+						integration.ResourceTags(integration.NetworkManager, deviceSrc, deviceOneName),
+					)
+					if err != nil {
+						t.Fatalf("failed to get device ID from search: %v", err)
+					}
+
+					// Get device: query format = globalNetworkID|deviceID
+					device, err := deviceSource.Get(ctx, globalScope, deviceOneCompositeID, true)
+					if err != nil {
+						t.Fatalf("failed to get device: %v", err)
+					}
+
+					deviceOneCompositeIDFromGet, err := integration.GetUniqueAttributeValue(
+						deviceUniqueAttribute,
+						[]*sdp.Item{device},
+						integration.ResourceTags(integration.NetworkManager, deviceSrc, deviceOneName),
+					)
+					if err != nil {
+						t.Fatalf("failed to get device ID from get: %v", err)
+					}
+
+					if deviceOneCompositeID != deviceOneCompositeIDFromGet {
+						t.Fatalf("expected device ID %s, got %s", deviceOneCompositeID, deviceOneCompositeIDFromGet)
+					}
+
+					deviceOneID := strings.Split(deviceOneCompositeID, "|")[1]
+
+					// Search devices by the global network ID
+					devicesByGlobalNetwork, err := deviceSource.Search(ctx, globalScope, globalNetworkID, true)
+					if err != nil {
+						t.Fatalf("failed to search for device by global network: %v", err)
+					}
+
+					integration.AssertEqualItems(t, devices, devicesByGlobalNetwork, deviceUniqueAttribute)
+
+					t.Run("Link Association", func(t *testing.T) {
+						// Search link associations by the global network ID, link ID
+						queryLALink := fmt.Sprintf("%s|link|%s", globalNetworkID, linkID)
+						linkAssociations, err := linkAssociationSource.Search(ctx, globalScope, queryLALink, true)
+						if err != nil {
+							t.Fatalf("failed to search for link association: %v", err)
+						}
+
+						if len(linkAssociations) == 0 {
+							t.Fatalf("no link associations found")
+						}
+
+						linkAssociationUniqueAttribute := linkAssociations[0].GetUniqueAttribute()
+
+						// composite link association id is in the format of: {globalNetworkID}|{linkID}|{deviceID}
+						compositeLinkAssociationID, err := integration.GetUniqueAttributeValue(
+							linkAssociationUniqueAttribute,
+							linkAssociations,
+							nil, // we didn't use tags on associations
+						)
+						if err != nil {
+							t.Fatalf("failed to get link association ID from search: %v", err)
+						}
+
+						// Get link association: query format = globalNetworkID|linkID|deviceID
+						linkAssociation, err := linkAssociationSource.Get(ctx, globalScope, compositeLinkAssociationID, true)
+						if err != nil {
+							t.Fatalf("failed to get link association: %v", err)
+						}
+
+						compositeLinkAssociationIDFromGet, err := integration.GetUniqueAttributeValue(
+							linkAssociationUniqueAttribute,
+							[]*sdp.Item{linkAssociation},
+							nil, // we didn't use tags on associations
+						)
+
+						if compositeLinkAssociationID != compositeLinkAssociationIDFromGet {
+							t.Fatalf("expected link association ID %s, got %s", compositeLinkAssociationID, compositeLinkAssociationIDFromGet)
+						}
+
+						// Search link associations by the global network ID
+						searchLinkAssociationsByGlobalNetwork, err := linkAssociationSource.Search(ctx, globalScope, globalNetworkID, true)
+						if err != nil {
+							t.Fatalf("failed to search for link association by global network: %v", err)
+						}
+
+						integration.AssertEqualItems(t, linkAssociations, searchLinkAssociationsByGlobalNetwork, linkAssociationUniqueAttribute)
+
+						// Search link associations by the global network ID and device ID
+						queryLADevice := fmt.Sprintf("%s|device|%s", globalNetworkID, deviceOneID)
+						linkAssociationsByDevice, err := linkAssociationSource.Search(ctx, globalScope, queryLADevice, true)
+						if err != nil {
+							t.Fatalf("failed to search for link association by device: %v", err)
+						}
+
+						integration.AssertEqualItems(t, linkAssociations, linkAssociationsByDevice, linkAssociationUniqueAttribute)
+					})
+
+					t.Run("Connection", func(t *testing.T) {
+						// Search connections by the global network ID
+						connections, err := connectionSource.Search(ctx, globalScope, globalNetworkID, true)
+						if err != nil {
+							t.Fatalf("failed to search for connection: %v", err)
+						}
+
+						if len(connections) == 0 {
+							t.Fatalf("no connections found")
+						}
+
+						connectionUniqueAttribute := connections[0].GetUniqueAttribute()
+
+						// composite connection id is in the format of: {globalNetworkID}|{connectionID}
+						compositeConnectionID, err := integration.GetUniqueAttributeValue(
+							connectionUniqueAttribute,
+							connections,
+							nil, // we didn't use tags on connections
+						)
+						if err != nil {
+							t.Fatalf("failed to get connection ID from search: %v", err)
+						}
+
+						// Get connection: query format = globalNetworkID|connectionID
+						connection, err := connectionSource.Get(ctx, globalScope, compositeConnectionID, true)
+						if err != nil {
+							t.Fatalf("failed to get connection: %v", err)
+						}
+
+						compositeConnectionIDFromGet, err := integration.GetUniqueAttributeValue(
+							connectionUniqueAttribute,
+							[]*sdp.Item{connection},
+							nil, // we didn't use tags on connections
+						)
+
+						if compositeConnectionID != compositeConnectionIDFromGet {
+							t.Fatalf("expected connection ID %s, got %s", compositeConnectionID, compositeConnectionIDFromGet)
+						}
+
+						// Search connections by global network ID and device ID
+						queryCon := fmt.Sprintf("%s|%s", globalNetworkID, deviceOneID)
+						connectionsByDevice, err := connectionSource.Search(ctx, globalScope, queryCon, true)
+						if err != nil {
+							t.Fatalf("failed to search for connection by device: %v", err)
+						}
+
+						integration.AssertEqualItems(t, connections, connectionsByDevice, connectionUniqueAttribute)
+					})
+				})
+			})
+		})
+	})
+}

--- a/sources/integration/networkmanager/setup.go
+++ b/sources/integration/networkmanager/setup.go
@@ -1,0 +1,83 @@
+package networkmanager
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+const (
+	globalNetworkSrc   = "global-network"
+	siteSrc            = "site"
+	linkSrc            = "link"
+	deviceSrc          = "device"
+	linkAssociationSrc = "link-association"
+	connectionSrc      = "connection"
+)
+
+const (
+	deviceOneName = "device-1"
+	deviceTwoName = "device-2"
+)
+
+func setup(ctx context.Context, logger *slog.Logger, networkmanagerClient *networkmanager.Client) error {
+	testID := integration.TestID()
+
+	// Create a global network
+	globalNetworkID, err := createGlobalNetwork(ctx, logger, networkmanagerClient, testID)
+	if err != nil {
+		return err
+	}
+
+	// Create a site in the global network
+	siteID, err := createSite(ctx, logger, networkmanagerClient, testID, globalNetworkID)
+	if err != nil {
+		return err
+	}
+
+	// Create a link in the global network for the site
+	linkID, err := createLink(ctx, logger, networkmanagerClient, testID, globalNetworkID, siteID)
+	if err != nil {
+		return err
+	}
+
+	// Create a device in the global network for the site
+	deviceOneID, err := createDevice(ctx, logger, networkmanagerClient, testID, globalNetworkID, siteID, deviceOneName)
+	if err != nil {
+		return err
+	}
+
+	// Create a link association in the global network for the device
+	err = createLinkAssociation(ctx, logger, networkmanagerClient, globalNetworkID, deviceOneID, linkID)
+	if err != nil {
+		return err
+	}
+
+	// Create another device in the global network for the site
+	deviceTwoID, err := createDevice(ctx, logger, networkmanagerClient, testID, globalNetworkID, siteID, deviceTwoName)
+	if err != nil {
+		return err
+	}
+
+	// Create a connection between the devices
+	err = createConnection(ctx, logger, networkmanagerClient, globalNetworkID, deviceOneID, deviceTwoID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func createNetworkManagerClient(ctx context.Context) (*networkmanager.Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	client := networkmanager.NewFromConfig(cfg)
+
+	return client, nil
+}

--- a/sources/integration/networkmanager/tags.go
+++ b/sources/integration/networkmanager/tags.go
@@ -1,0 +1,48 @@
+package networkmanager
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func resourceTags(resourceName, testID string, additionalAttr ...string) []types.Tag {
+	return []types.Tag{
+		{
+			Key:   aws.String(integration.TagTestKey),
+			Value: aws.String(integration.TagTestValue),
+		},
+		{
+			Key:   aws.String(integration.TagTestTypeKey),
+			Value: aws.String(integration.TestName(integration.NetworkManager)),
+		},
+		{
+			Key:   aws.String(integration.TagTestIDKey),
+			Value: aws.String(testID),
+		},
+		{
+			Key:   aws.String(integration.TagResourceIDKey),
+			Value: aws.String(integration.ResourceName(integration.NetworkManager, resourceName, additionalAttr...)),
+		},
+	}
+}
+
+func hasTags(tags []types.Tag, requiredTags []types.Tag) bool {
+	rT := make(map[string]string)
+	for _, t := range requiredTags {
+		rT[*t.Key] = *t.Value
+	}
+
+	oT := make(map[string]string)
+	for _, t := range tags {
+		oT[*t.Key] = *t.Value
+	}
+
+	for k, v := range rT {
+		if oT[k] != v {
+			return false
+		}
+	}
+
+	return true
+}

--- a/sources/integration/networkmanager/teardown.go
+++ b/sources/integration/networkmanager/teardown.go
@@ -1,0 +1,150 @@
+package networkmanager
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
+	"github.com/overmindtech/aws-source/sources/integration"
+)
+
+func teardown(ctx context.Context, logger *slog.Logger, client *networkmanager.Client) error {
+	globalNetworkID, err := findGlobalNetworkIDByTags(ctx, client, resourceTags(globalNetworkSrc, integration.TestID()))
+	if err != nil {
+		nf := integration.NewNotFoundError(globalNetworkSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Global network not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	siteID, err := findSiteIDByTags(ctx, client, globalNetworkID, resourceTags(siteSrc, integration.TestID()))
+	if err != nil {
+		nf := integration.NewNotFoundError(siteSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Site not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	linkID, err := findLinkIDByTags(ctx, client, globalNetworkID, siteID, resourceTags(linkSrc, integration.TestID()))
+	if err != nil {
+		nf := integration.NewNotFoundError(linkSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Link not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	deviceOneID, err := findDeviceIDByTags(ctx, client, globalNetworkID, siteID, resourceTags(deviceSrc, integration.TestID(), deviceOneName))
+	if err != nil {
+		nf := integration.NewNotFoundError(deviceSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Device not found", "name", deviceOneName)
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	err = deleteLinkAssociation(ctx, client, globalNetworkID, deviceOneID, linkID)
+	if err != nil {
+		nf := integration.NewNotFoundError(linkAssociationSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Link association not found.. ignoring")
+		} else {
+			return err
+		}
+	}
+
+	connectionID, err := findConnectionID(ctx, client, globalNetworkID, deviceOneID)
+	if err != nil {
+		nf := integration.NewNotFoundError(connectionSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Connection not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	err = deleteConnection(ctx, client, globalNetworkID, connectionID)
+	if err != nil {
+		nf := integration.NewNotFoundError(connectionSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Connection not found.. ignoring", "id", connectionID)
+		} else {
+			return err
+		}
+	}
+
+	err = deleteDevice(ctx, client, globalNetworkID, deviceOneID)
+	if err != nil {
+		nf := integration.NewNotFoundError(deviceSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Device not found.. ignoring", "id", deviceOneID)
+		} else {
+			return err
+		}
+	}
+
+	deviceTwoID, err := findDeviceIDByTags(ctx, client, globalNetworkID, siteID, resourceTags(deviceSrc, integration.TestID(), deviceTwoName))
+	if err != nil {
+		nf := integration.NewNotFoundError(deviceSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Device not found")
+			return nil
+		} else {
+			return err
+		}
+	}
+
+	err = deleteDevice(ctx, client, globalNetworkID, deviceTwoID)
+	if err != nil {
+		nf := integration.NewNotFoundError(deviceSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Device not found.. ignoring", "id", deviceTwoID)
+		} else {
+			return err
+		}
+	}
+
+	err = deleteLink(ctx, client, globalNetworkID, linkID)
+	if err != nil {
+		nf := integration.NewNotFoundError(linkSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Link not found.. ignoring", "id", linkID)
+		} else {
+			return err
+		}
+	}
+
+	err = deleteSite(ctx, client, globalNetworkID, siteID)
+	if err != nil {
+		nf := integration.NewNotFoundError(siteSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Site not found.. ignoring", "id", siteID)
+		} else {
+			return err
+		}
+	}
+
+	err = deleteGlobalNetwork(ctx, client, *globalNetworkID)
+	if err != nil {
+		nf := integration.NewNotFoundError(globalNetworkSrc)
+		if errors.As(err, &nf) {
+			logger.WarnContext(ctx, "Global network not found.. ignoring", "id", globalNetworkID)
+		} else {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/sources/integration/util.go
+++ b/sources/integration/util.go
@@ -1,0 +1,215 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
+	"github.com/overmindtech/sdp-go"
+)
+
+const (
+	TagTestKey       = "test"
+	TagTestValue     = "true"
+	TagTestIDKey     = "test-id"
+	TagTestTypeKey   = "test-type"
+	TagResourceIDKey = "resource-id"
+)
+
+type resourceGroup int
+
+const (
+	NetworkManager resourceGroup = iota
+	EC2
+)
+
+func (rg resourceGroup) String() string {
+	switch rg {
+	case NetworkManager:
+		return "network-manager"
+	case EC2:
+		return "ec2"
+	default:
+		return "unknown"
+	}
+}
+
+func ShouldRunIntegrationTests() bool {
+	run, found := os.LookupEnv("RUN_INTEGRATION_TESTS")
+
+	if !found {
+		return false
+	}
+
+	shouldRun, err := strconv.ParseBool(run)
+	if err != nil {
+		return false
+	}
+
+	return shouldRun
+}
+
+func TestID() string {
+	tagTestID, found := os.LookupEnv("INTEGRATION_TEST_ID")
+	if !found {
+		var err error
+		tagTestID, err = os.Hostname()
+		if err != nil {
+			panic("failed to get hostname")
+		}
+	}
+
+	return tagTestID
+}
+
+func TestName(resourceGroup resourceGroup) string {
+	return fmt.Sprintf("%s-integration-tests", resourceGroup.String())
+}
+
+func TagFilter(resourceGroup resourceGroup) []types.TagFilter {
+	return []types.TagFilter{
+		{
+			Key:    aws.String(TagTestTypeKey),
+			Values: []string{TestName(resourceGroup)},
+		},
+		{
+			Key:    aws.String(TagTestIDKey),
+			Values: []string{TestID()},
+		},
+		{
+			Key:    aws.String(TagTestKey),
+			Values: []string{TagTestValue},
+		},
+	}
+}
+
+type AWSCfg struct {
+	AccountID string
+	Region    string
+}
+
+func AWSSettings(ctx context.Context) (*AWSCfg, error) {
+	accountID, found := os.LookupEnv("AWS_ACCOUNT_ID")
+	if !found {
+		return nil, fmt.Errorf("AWS_ACCOUNT_ID not found")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AWSCfg{
+		AccountID: accountID,
+		Region:    cfg.Region,
+	}, nil
+}
+
+func removeUnhealthy(sdpInstances []*sdp.Item) []*sdp.Item {
+	var filteredInstances []*sdp.Item
+	for _, instance := range sdpInstances {
+		if instance.GetHealth() != sdp.Health_HEALTH_OK {
+			continue
+		}
+		filteredInstances = append(filteredInstances, instance)
+	}
+	return filteredInstances
+}
+
+func GetUniqueAttributeValue(uniqueAttrKey string, items []*sdp.Item, filterTags map[string]string) (string, error) {
+	var filteredItems []*sdp.Item
+	for _, item := range removeUnhealthy(items) {
+		if hasTags(item.GetTags(), filterTags) {
+			filteredItems = append(filteredItems, item)
+		}
+	}
+
+	if len(filteredItems) != 1 {
+		return "", fmt.Errorf("expected 1 item, got %v", len(filteredItems))
+	}
+
+	uniqueAttrValue, err := filteredItems[0].GetAttributes().Get(uniqueAttrKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to get %s: %v", uniqueAttrKey, err)
+	}
+
+	uniqueAttrValueStr := uniqueAttrValue.(string)
+	if uniqueAttrValueStr == "" {
+		return "", fmt.Errorf("%s is empty", uniqueAttrKey)
+	}
+
+	return uniqueAttrValueStr, nil
+}
+
+// ResourceName returns a unique resource name for integration tests
+// I.e., integration-test-networkmanager-global-network-1
+func ResourceName(resourceGroup resourceGroup, resourceName string, additionalAttr ...string) string {
+	name := []string{"integration-test", resourceGroup.String(), resourceName}
+
+	name = append(name, additionalAttr...)
+
+	return strings.Join(name, "-")
+}
+
+func ResourceTags(resourceGroup resourceGroup, resourceName string, additionalAttr ...string) map[string]string {
+	return map[string]string{
+		TagTestKey:       TagTestValue,
+		TagTestTypeKey:   TestName(resourceGroup),
+		TagTestIDKey:     TestID(),
+		TagResourceIDKey: ResourceName(resourceGroup, resourceName, additionalAttr...),
+	}
+}
+
+func hasTags(tags map[string]string, requiredTags map[string]string) bool {
+	for k, v := range requiredTags {
+		if tags[k] != v {
+			return false
+		}
+	}
+
+	return true
+}
+
+func AssertEqualItems(t *testing.T, expected, actual []*sdp.Item, uniqueAttrKey string) {
+	if len(expected) != len(actual) {
+		t.Fatalf("expected %d items, got %d", len(expected), len(actual))
+	}
+
+	expectedUnqAttrValSet, err := uniqueAttributeValueSet(expected, uniqueAttrKey)
+	if err != nil {
+		t.Fatalf("failed to get unique attribute value set: %v", err)
+	}
+
+	actualUnqAttrValSet, err := uniqueAttributeValueSet(actual, uniqueAttrKey)
+	if err != nil {
+		t.Fatalf("failed to get unique attribute value set: %v", err)
+	}
+
+	if len(expectedUnqAttrValSet) != len(actualUnqAttrValSet) {
+		t.Fatalf("expected %d unique values, got %d", len(expectedUnqAttrValSet), len(actualUnqAttrValSet))
+	}
+
+	for val := range expectedUnqAttrValSet {
+		if _, ok := actualUnqAttrValSet[val]; !ok {
+			t.Fatalf("expected value %v not found in actual", val)
+		}
+	}
+}
+
+func uniqueAttributeValueSet(items []*sdp.Item, key string) (map[any]bool, error) {
+	uniqueValues := make(map[any]bool)
+	for _, item := range items {
+		value, err := item.GetAttributes().Get(key)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get %s: %v", key, err)
+		}
+		uniqueValues[value] = true
+	}
+	return uniqueValues, nil
+}

--- a/sources/integration/util_test.go
+++ b/sources/integration/util_test.go
@@ -1,0 +1,36 @@
+package integration
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_testID(t *testing.T) {
+	t.Run("test id is given via env var", func(t *testing.T) {
+		err := os.Setenv("INTEGRATION_TEST_ID", "test-id")
+		if err != nil {
+			t.Error(err)
+		}
+		defer func() {
+			err := os.Unsetenv("INTEGRATION_TEST_ID")
+			if err != nil {
+				t.Error(err)
+			}
+		}()
+
+		if got := TestID(); got != "test-id" {
+			t.Errorf("TestID() = %v, want %v", got, "test-id")
+		}
+	})
+
+	t.Run("test id is not given via env var - defaults to host name", func(t *testing.T) {
+		err := os.Unsetenv("INTEGRATION_TEST_ID")
+		if err != nil {
+			t.Error(err)
+		}
+
+		if got := TestID(); got == "" {
+			t.Errorf("TestID() = %v, want not empty", got)
+		}
+	})
+}

--- a/sources/networkmanager/connection.go
+++ b/sources/networkmanager/connection.go
@@ -141,17 +141,15 @@ func connectionOutputMapper(_ context.Context, _ *networkmanager.Client, scope s
 // +overmind:type networkmanager-connection
 // +overmind:descriptiveType Networkmanager Connection
 // +overmind:get Get a Networkmanager Connection
-// +overmind:list List all Networkmanager Connections
 // +overmind:search Search for Networkmanager Connections by GlobalNetworkId
 // +overmind:group AWS
 // +overmind:terraform:queryMap aws_networkmanager_connection.arn
 // +overmind:terraform:method SEARCH
 
-func NewConnectionSource(client *networkmanager.Client, accountID, region string) *sources.DescribeOnlySource[*networkmanager.GetConnectionsInput, *networkmanager.GetConnectionsOutput, *networkmanager.Client, *networkmanager.Options] {
+func NewConnectionSource(client *networkmanager.Client, accountID string) *sources.DescribeOnlySource[*networkmanager.GetConnectionsInput, *networkmanager.GetConnectionsOutput, *networkmanager.Client, *networkmanager.Options] {
 	return &sources.DescribeOnlySource[*networkmanager.GetConnectionsInput, *networkmanager.GetConnectionsOutput, *networkmanager.Client, *networkmanager.Options]{
 		Client:    client,
 		AccountID: accountID,
-		Region:    region,
 		ItemType:  "networkmanager-connection",
 		DescribeFunc: func(ctx context.Context, client *networkmanager.Client, input *networkmanager.GetConnectionsInput) (*networkmanager.GetConnectionsOutput, error) {
 			return client.GetConnections(ctx, input)

--- a/sources/networkmanager/device.go
+++ b/sources/networkmanager/device.go
@@ -135,17 +135,15 @@ func deviceOutputMapper(_ context.Context, _ *networkmanager.Client, scope strin
 // +overmind:type networkmanager-device
 // +overmind:descriptiveType Networkmanager Device
 // +overmind:get Get a Networkmanager Device
-// +overmind:list List all Networkmanager Devices
 // +overmind:search Search for Networkmanager Devices by GlobalNetworkId, or by GlobalNetworkId with SiteId
 // +overmind:group AWS
 // +overmind:terraform:queryMap aws_networkmanager_device.arn
 // +overmind:terraform:method SEARCH
 
-func NewDeviceSource(client *networkmanager.Client, accountID, region string) *sources.DescribeOnlySource[*networkmanager.GetDevicesInput, *networkmanager.GetDevicesOutput, *networkmanager.Client, *networkmanager.Options] {
+func NewDeviceSource(client *networkmanager.Client, accountID string) *sources.DescribeOnlySource[*networkmanager.GetDevicesInput, *networkmanager.GetDevicesOutput, *networkmanager.Client, *networkmanager.Options] {
 	return &sources.DescribeOnlySource[*networkmanager.GetDevicesInput, *networkmanager.GetDevicesOutput, *networkmanager.Client, *networkmanager.Options]{
 		Client:    client,
 		AccountID: accountID,
-		Region:    region,
 		ItemType:  "networkmanager-device",
 		DescribeFunc: func(ctx context.Context, client *networkmanager.Client, input *networkmanager.GetDevicesInput) (*networkmanager.GetDevicesOutput, error) {
 			return client.GetDevices(ctx, input)

--- a/sources/networkmanager/global_network.go
+++ b/sources/networkmanager/global_network.go
@@ -178,11 +178,10 @@ func globalNetworkOutputMapper(_ context.Context, client *networkmanager.Client,
 // +overmind:terraform:queryMap aws_networkmanager_global_network.arn
 // +overmind:terraform:method SEARCH
 
-func NewGlobalNetworkSource(client *networkmanager.Client, accountID string, region string) *sources.DescribeOnlySource[*networkmanager.DescribeGlobalNetworksInput, *networkmanager.DescribeGlobalNetworksOutput, *networkmanager.Client, *networkmanager.Options] {
+func NewGlobalNetworkSource(client *networkmanager.Client, accountID string) *sources.DescribeOnlySource[*networkmanager.DescribeGlobalNetworksInput, *networkmanager.DescribeGlobalNetworksOutput, *networkmanager.Client, *networkmanager.Options] {
 	return &sources.DescribeOnlySource[*networkmanager.DescribeGlobalNetworksInput, *networkmanager.DescribeGlobalNetworksOutput, *networkmanager.Client, *networkmanager.Options]{
 		ItemType:  "networkmanager-global-network",
 		Client:    client,
-		Region:    region,
 		AccountID: accountID,
 		DescribeFunc: func(ctx context.Context, client *networkmanager.Client, input *networkmanager.DescribeGlobalNetworksInput) (*networkmanager.DescribeGlobalNetworksOutput, error) {
 			return client.DescribeGlobalNetworks(ctx, input)

--- a/sources/networkmanager/link.go
+++ b/sources/networkmanager/link.go
@@ -2,6 +2,7 @@ package networkmanager
 
 import (
 	"context"
+	"github.com/aws/aws-sdk-go-v2/service/networkmanager/types"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/networkmanager"
@@ -95,6 +96,17 @@ func linkOutputMapper(_ context.Context, _ *networkmanager.Client, scope string,
 			})
 		}
 
+		switch s.State {
+		case types.LinkStatePending:
+			item.Health = sdp.Health_HEALTH_PENDING.Enum()
+		case types.LinkStateAvailable:
+			item.Health = sdp.Health_HEALTH_OK.Enum()
+		case types.LinkStateDeleting:
+			item.Health = sdp.Health_HEALTH_PENDING.Enum()
+		case types.LinkStateUpdating:
+			item.Health = sdp.Health_HEALTH_PENDING.Enum()
+		}
+
 		items = append(items, &item)
 	}
 
@@ -105,17 +117,15 @@ func linkOutputMapper(_ context.Context, _ *networkmanager.Client, scope string,
 // +overmind:type networkmanager-link
 // +overmind:descriptiveType Networkmanager Link
 // +overmind:get Get a Networkmanager Link
-// +overmind:list List all Networkmanager Links
 // +overmind:search Search for Networkmanager Links by GlobalNetworkId, or by GlobalNetworkId with SiteId
 // +overmind:group AWS
 // +overmind:terraform:queryMap aws_networkmanager_link.arn
 // +overmind:terraform:method SEARCH
 
-func NewLinkSource(client *networkmanager.Client, accountID, region string) *sources.DescribeOnlySource[*networkmanager.GetLinksInput, *networkmanager.GetLinksOutput, *networkmanager.Client, *networkmanager.Options] {
+func NewLinkSource(client *networkmanager.Client, accountID string) *sources.DescribeOnlySource[*networkmanager.GetLinksInput, *networkmanager.GetLinksOutput, *networkmanager.Client, *networkmanager.Options] {
 	return &sources.DescribeOnlySource[*networkmanager.GetLinksInput, *networkmanager.GetLinksOutput, *networkmanager.Client, *networkmanager.Options]{
 		Client:    client,
 		AccountID: accountID,
-		Region:    region,
 		ItemType:  "networkmanager-link",
 		DescribeFunc: func(ctx context.Context, client *networkmanager.Client, input *networkmanager.GetLinksInput) (*networkmanager.GetLinksOutput, error) {
 			return client.GetLinks(ctx, input)

--- a/sources/networkmanager/site.go
+++ b/sources/networkmanager/site.go
@@ -102,16 +102,14 @@ func siteOutputMapper(_ context.Context, _ *networkmanager.Client, scope string,
 // +overmind:type networkmanager-site
 // +overmind:descriptiveType Networkmanager Site
 // +overmind:get Get a Networkmanager Site
-// +overmind:list List all Networkmanager Sites
 // +overmind:search Search for Networkmanager Sites by GlobalNetworkId
 // +overmind:group AWS
 // +overmind:terraform:queryMap aws_networkmanager_site.arn
 // +overmind:terraform:method SEARCH
 
-func NewSiteSource(client *networkmanager.Client, accountID, region string) *sources.DescribeOnlySource[*networkmanager.GetSitesInput, *networkmanager.GetSitesOutput, *networkmanager.Client, *networkmanager.Options] {
+func NewSiteSource(client *networkmanager.Client, accountID string) *sources.DescribeOnlySource[*networkmanager.GetSitesInput, *networkmanager.GetSitesOutput, *networkmanager.Client, *networkmanager.Options] {
 	return &sources.DescribeOnlySource[*networkmanager.GetSitesInput, *networkmanager.GetSitesOutput, *networkmanager.Client, *networkmanager.Options]{
 		Client:    client,
-		Region:    region,
 		AccountID: accountID,
 		ItemType:  "networkmanager-site",
 		DescribeFunc: func(ctx context.Context, client *networkmanager.Client, input *networkmanager.GetSitesInput) (*networkmanager.GetSitesOutput, error) {


### PR DESCRIPTION
# What
- Add integration test for EC2 instance: This is to test generalising integration test framework
- Add integration tests for networkmanager: globalnetwork, site, device, link, linkassociation, connection