### PR TITLE
Fixed caching for `GetList` sources. Fixes #553

### DIFF
--- a/docs-data/route53-resource-record-set.json
+++ b/docs-data/route53-resource-record-set.json
@@ -3,7 +3,7 @@
 	"descriptiveType": "Route53 Record Set",
 	"getDescription": "Get a Route53 record Set by name",
 	"listDescription": "List all record sets",
-	"searchDescription": "Search for a record set by ARN",
+	"searchDescription": "Search for a record set by hosted zone ID",
 	"group": "AWS",
 	"terraformQuery": [
 		"aws_route53_record.arn"

--- a/sources/route53/resource_record_set.go
+++ b/sources/route53/resource_record_set.go
@@ -75,7 +75,7 @@ func resourceRecordSetItemMapper(scope string, awsItem *types.ResourceRecordSet)
 // +overmind:descriptiveType Route53 Record Set
 // +overmind:get Get a Route53 record Set by name
 // +overmind:list List all record sets
-// +overmind:search Search for a record set by ARN
+// +overmind:search Search for a record set by hosted zone ID
 // +overmind:group AWS
 // +overmind:terraform:queryMap aws_route53_record.arn
 // +overmind:terraform:method SEARCH

--- a/sources/util.go
+++ b/sources/util.go
@@ -43,6 +43,18 @@ func ParseScope(scope string) (string, string, error) {
 	return sections[0], sections[1], nil
 }
 
+// Returns whether or not it makes sense to retry the error. This can be used to
+// decide whether we should cache the error or not. Errors such as the item
+// being not found, or the scope not existing should not be retried for example
+func CanRetry(err *sdp.QueryError) bool {
+	switch err.GetErrorType() {
+	case sdp.QueryError_NOTFOUND, sdp.QueryError_NOSCOPE:
+		return false
+	default:
+		return true
+	}
+}
+
 // A parsed representation of the parts of the ARN that Overmind needs to care
 // about
 //


### PR DESCRIPTION
* Fixed a bug that caused `GetList` sources with a custom `SEARCH` method to not be cached
* Cleanup and standardise caching code