### PR TITLE
Capture a cleaner service version

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -22,7 +22,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
 
-//go:generate sh -c "echo -n $(git describe --tags --long --all) > commit.txt"
+//go:generate sh -c "echo -n $(git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD) > commit.txt"
 //go:embed commit.txt
 var ServiceVersion string
 


### PR DESCRIPTION
This means that we get either the SHA of of the commit, or the tag, rather than the somewhat confusing `heads/main-0-gd4c5dc9` that we get at the moment. This is especially confusing since the SHA is the 7 digits, not 8 (i.e. `d4c5dc9` not `gd4c5dc9`)