### PR TITLE
(fix) change the location of the termination-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,21 +61,19 @@ This source requires the following IAM Policy
 
 Types are named to match the `describe-*`, `get-*` or `list-*` command within the AWS CLI, with the service that they are part of as a prefix. For example to get the details if a security group you would run:
 
-```
+````bash
 aws ec2 describe-security-groups
 ```
 
 Meaning that the type in Overmind should be:
 
-```
-ec2-security-group
-```
+`ec2-security-group`
 
 Note that plurals should be converted to their singular form hence `security-groups` becomes `security-group`
 
 ## Rate limiting
 
-For EC2 APIs this sources uses the [same throttling methods as EC2 does](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html), with the bucket size and refill rate set to 50% of the total. This means that the source will never use more than 50% of the available requests, including refil;ls when the bucket is empty.
+For EC2 APIs this sources uses the [same throttling methods as EC2 does](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/throttling.html), with the bucket size and refill rate set to 50% of the total. This means that the source will never use more than 50% of the available requests, including refills when the bucket is empty.
 
 ## Config
 
@@ -205,6 +203,7 @@ Source data for docs is stored in `docs-data` and can be generated using:
 Ensure that [`docgen`](https://github.com/overmindtech/docgen) is installed.
 
 From the root of the project run:
+
 ```shell
 go generate ./...
 ```

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,5 +1,5 @@
 # Build the source binary
-FROM golang:1.23-alpine as builder
+FROM golang:1.23-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -29,6 +29,8 @@ RUN --mount=type=cache,target=/go/pkg \
 FROM alpine:3.20
 WORKDIR /
 COPY --from=builder /workspace/source .
+# create our termination log folder
+RUN mkdir -p /log && chown -R nobody:nobody /log
 USER 65534:65534
 
 ENTRYPOINT ["/source"]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -359,7 +359,7 @@ func (t TerminationLogHook) Levels() []log.Level {
 }
 
 func (t TerminationLogHook) Fire(e *log.Entry) error {
-	tLog, err := os.OpenFile("/dev/termination-log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	tLog, err := os.OpenFile("/log/termination-log", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
when running the container, it would fail creating the termination-log 

```shell
2024/09/04 15:46:03 maxprocs: Leaving GOMAXPROCS=16: CPU quota undefined
time="2024-09-04T15:46:03Z" level=info msg="otlptracehttp client configured itself: &{traces {localhost:4318 false <nil> map[] 0 10000000000 /v1/traces <nil> <nil>} {{localhost:4318 false <nil> map[] 0 10000000000 /v1/traces <nil> <nil>} {true 5000000000 30000000000 60000000000} 0  [] <nil>} 0x3b0c4a0 0xc00073fa70 0xc0001821c0 {{{} 0} {0 0}}}"
time="2024-09-04T15:46:04Z" level=info msg="Got config" auto-config=false aws-access-strategy=defaults aws-external-id= aws-profile= aws-regions="[]" aws-target-role-arn= health-check-port=8080 max-parallel=2000 nats-jwt= nats-name-prefix= nats-nkey-seed= nats-servers="[nats://localhost:4222 nats://nats:4222]"
Failed to fire hook: open /dev/termination-log: permission denied
time="2024-09-04T15:46:04Z" level=fatal msg="Could not create AWS configs" error="no regions specified"
```

We change the default user in the dockerfile, which has no access to /dev. we can set an arbitary path for kubernetes to pick up our log 

https://github.com/overmindtech/aws-source/issues/596