### PR TITLE
Pass region to STS config too

### DIFF
--- a/proc/proc.go
+++ b/proc/proc.go
@@ -122,7 +122,7 @@ func (c AwsAuthConfig) GetAWSConfig(region string) (aws.Config, error) {
 			return aws.Config{}, errors.New("with external-id strategy, aws-profile must be blank")
 		}
 
-		assumeConfig, err := config.LoadDefaultConfig(ctx)
+		assumeConfig, err := config.LoadDefaultConfig(ctx, options...)
 		if err != nil {
 			return aws.Config{}, fmt.Errorf("could not load default config from environment: %w", err)
 		}


### PR DESCRIPTION
This means that STS will auth against the correct regional endpoint

Fixes #680