### PR TITLE
Allow linking using wildcards in ARNs

### DIFF
--- a/adapterhelpers/always_get_source.go
+++ b/adapterhelpers/always_get_source.go
@@ -433,6 +433,15 @@ func (s *AlwaysGetAdapter[ListInput, ListOutput, GetInput, GetOutput, ClientStru
 		return nil, WrapAWSError(err)
 	}
 
+	if a.ContainsWildcard() {
+		// We can't handle wildcards by default so bail out
+		return nil, &sdp.QueryError{
+			ErrorType:   sdp.QueryError_NOTFOUND,
+			ErrorString: fmt.Sprintf("wildcards are not supported by adapter %v", s.Name()),
+			Scope:       scope,
+		}
+	}
+
 	if arnScope := FormatScope(a.AccountID, a.Region); arnScope != scope {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,

--- a/adapterhelpers/describe_source.go
+++ b/adapterhelpers/describe_source.go
@@ -339,6 +339,15 @@ func (s *DescribeOnlyAdapter[Input, Output, ClientStruct, Options]) searchARN(ct
 		return nil, WrapAWSError(err)
 	}
 
+	if a.ContainsWildcard() {
+		// We can't handle wildcards by default so bail out
+		return nil, &sdp.QueryError{
+			ErrorType:   sdp.QueryError_NOTFOUND,
+			ErrorString: fmt.Sprintf("wildcards are not supported by adapter %v", s.Name()),
+			Scope:       scope,
+		}
+	}
+
 	if arnScope := FormatScope(a.AccountID, a.Region); arnScope != scope {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,

--- a/adapterhelpers/get_list_source.go
+++ b/adapterhelpers/get_list_source.go
@@ -262,6 +262,15 @@ func (s *GetListAdapter[AWSItem, ClientStruct, Options]) SearchARN(ctx context.C
 		return nil, WrapAWSError(err)
 	}
 
+	if a.ContainsWildcard() {
+		// We can't handle wildcards by default so bail out
+		return nil, &sdp.QueryError{
+			ErrorType:   sdp.QueryError_NOTFOUND,
+			ErrorString: fmt.Sprintf("wildcards are not supported by adapter %v", s.Name()),
+			Scope:       scope,
+		}
+	}
+
 	if arnScope := FormatScope(a.AccountID, a.Region); !s.hasScope(arnScope) {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,

--- a/adapterhelpers/util.go
+++ b/adapterhelpers/util.go
@@ -150,6 +150,11 @@ func (a *ARN) IAMWildcardMatches(arn string) bool {
 	return true
 }
 
+func (a *ARN) ContainsWildcard() bool {
+	possibleWildcardLocations := a.Partition + a.Region + a.AccountID + a.Resource
+	return strings.Contains(possibleWildcardLocations, "*") || strings.Contains(possibleWildcardLocations, "?")
+}
+
 // ParseARN Parses an ARN and tries to determine the resource ID from it. The
 // logic is that the resource ID will be the last component when separated by
 // slashes or colons: https://devopscube.com/aws-arn-guide/

--- a/adapters/iam.go
+++ b/adapters/iam.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/micahhausler/aws-iam-policy/policy"
@@ -90,12 +89,6 @@ func LinksFromPolicy(document *policy.Policy) []*sdp.LinkedItemQuery {
 			for _, resource := range statement.Resource.Values() {
 				arn, err = adapterhelpers.ParseARN(resource)
 				if err != nil {
-					continue
-				}
-
-				// If the ARN contains a wildcard then we want to bail out
-				possibleWildcards := arn.AccountID + arn.Type() + arn.ResourceID()
-				if strings.Contains(possibleWildcards, "*") {
 					continue
 				}
 


### PR DESCRIPTION
This allows wildcards in IAM policies to trigger ARN Search queries. However it also adds logic so that every source that doesn't explicitly support this will immediately respond saying so